### PR TITLE
Fix sign-in state not persisting on navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1570,6 +1570,7 @@
             "version": "1.7.1",
             "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
             "integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -1595,6 +1596,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1611,6 +1613,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1627,6 +1630,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1643,6 +1647,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1659,6 +1664,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1675,6 +1681,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1691,6 +1698,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1707,6 +1715,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1723,6 +1732,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1739,6 +1749,7 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1755,6 +1766,7 @@
             "cpu": [
                 "loong64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1771,6 +1783,7 @@
             "cpu": [
                 "mips64el"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1787,6 +1800,7 @@
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1803,6 +1817,7 @@
             "cpu": [
                 "riscv64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1819,6 +1834,7 @@
             "cpu": [
                 "s390x"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1835,6 +1851,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1851,6 +1868,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1867,6 +1885,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1883,6 +1902,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1899,6 +1919,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1915,6 +1936,7 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1931,6 +1953,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2828,6 +2851,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -2850,6 +2874,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -2872,6 +2897,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2888,6 +2914,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2904,6 +2931,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2920,6 +2948,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2936,6 +2965,7 @@
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2952,6 +2982,7 @@
             "cpu": [
                 "riscv64"
             ],
+            "dev": true,
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2968,6 +2999,7 @@
             "cpu": [
                 "s390x"
             ],
+            "dev": true,
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2984,6 +3016,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -3000,6 +3033,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -3016,6 +3050,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -3032,6 +3067,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -3054,6 +3090,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -3076,6 +3113,7 @@
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -3098,6 +3136,7 @@
             "cpu": [
                 "riscv64"
             ],
+            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -3120,6 +3159,7 @@
             "cpu": [
                 "s390x"
             ],
+            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -3142,6 +3182,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -3164,6 +3205,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -3186,6 +3228,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -3208,6 +3251,7 @@
             "cpu": [
                 "wasm32"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
             "optional": true,
             "dependencies": {
@@ -3227,6 +3271,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -3246,6 +3291,7 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -3265,6 +3311,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -12722,6 +12769,7 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
             "license": "0BSD",
             "optional": true
         },

--- a/src/components/app/UserMenu.svelte
+++ b/src/components/app/UserMenu.svelte
@@ -11,8 +11,7 @@
     const { user = null } = $props<{ user: BentoBetterAuthUser | null }>();
 
     const sessionStore = svelteAuthClient.useSession();
-    let session = $state(sessionStore);
-    const currentUser = $derived.by(() => user ?? session?.value?.data?.user ?? null);
+    const currentUser = $derived.by(() => user ?? sessionStore?.value?.data?.user ?? null);
 
     let open = $state(false);
     let menuElement: HTMLDivElement | null = $state(null);


### PR DESCRIPTION
Fixed issue https://github.com/thebentobot/bento-web/issues/203 where authenticated users would appear signed out after navigating to a new page until force refresh.

The problem was in UserMenu.svelte where the session store from better-auth wasn't properly subscribed to for reactivity. Changed from wrapping sessionStore in $state() to directly accessing sessionStore.value in the $derived block, which properly tracks session updates in Svelte 5.

This ensures that:
- Session state persists across client-side navigation
- User authentication status updates reactively
- No force refresh needed after sign-in