### PR TITLE
Fix user redirect and state after sign out

### DIFF
--- a/src/components/app/UserMenu.svelte
+++ b/src/components/app/UserMenu.svelte
@@ -71,14 +71,7 @@
         await svelteAuthClient.signIn.social({ provider: "discord" });
     };
     const LogOut = async () => {
-        try {
-            await svelteAuthClient.signOut();
-        } catch (error) {
-            console.error("Failed to sign out:", error);
-            return;
-        }
-
-        // Redirect to home page after successful sign-out
+        await svelteAuthClient.signOut();
         window.location.href = "/";
     };
 

--- a/src/components/app/UserMenu.svelte
+++ b/src/components/app/UserMenu.svelte
@@ -71,7 +71,13 @@
         await svelteAuthClient.signIn.social({ provider: "discord" });
     };
     const LogOut = async () => {
-        await svelteAuthClient.signOut();
+        try {
+            await svelteAuthClient.signOut();
+        } catch (error) {
+            console.error("Failed to sign out:", error);
+            return;
+        }
+
         // Redirect to home page after successful sign-out
         window.location.href = "/";
     };

--- a/src/components/app/UserMenu.svelte
+++ b/src/components/app/UserMenu.svelte
@@ -72,6 +72,8 @@
     };
     const LogOut = async () => {
         await svelteAuthClient.signOut();
+        // Redirect to home page after successful sign-out
+        window.location.href = "/";
     };
 
     let confirmOpen = $state(false);

--- a/src/components/auth/SignOutButton.svelte
+++ b/src/components/auth/SignOutButton.svelte
@@ -12,15 +12,18 @@
         loading = true;
         try {
             await svelteAuthClient.signOut();
+            window.location.href = "/";
         } catch (e) {
             console.error("Sign out failed", e);
+            try {
+                window.location.href = "/";
+            } catch (err) {
+                console.debug("Fallback navigation to / failed", err);
+            }
+        } finally {
             loading = false;
             confirmOpen = false;
-            return;
         }
-
-        // Redirect to home page after successful sign-out
-        window.location.href = "/";
     };
 </script>
 

--- a/src/components/auth/SignOutButton.svelte
+++ b/src/components/auth/SignOutButton.svelte
@@ -12,7 +12,8 @@
         loading = true;
         try {
             await svelteAuthClient.signOut();
-            window.location.reload();
+            // Redirect to home page after successful sign-out
+            window.location.href = "/";
         } catch (e) {
             console.error("Sign out failed", e);
             try {

--- a/src/components/auth/SignOutButton.svelte
+++ b/src/components/auth/SignOutButton.svelte
@@ -12,19 +12,15 @@
         loading = true;
         try {
             await svelteAuthClient.signOut();
-            // Redirect to home page after successful sign-out
-            window.location.href = "/";
         } catch (e) {
             console.error("Sign out failed", e);
-            try {
-                window.location.href = "/";
-            } catch (err) {
-                console.debug("Fallback navigation to / failed", err);
-            }
-        } finally {
             loading = false;
             confirmOpen = false;
+            return;
         }
+
+        // Redirect to home page after successful sign-out
+        window.location.href = "/";
     };
 </script>
 


### PR DESCRIPTION
- Change SignOutButton to redirect to "/" instead of reloading current page
- Add redirect to UserMenu's sign-out handler for consistent behavior
- Ensures users are not left on protected pages after signing out
- Resolves issue #202