### PR TITLE
feat: migrate leaderboard and Patreon components to Svelte

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1157,6 +1157,7 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "workerd": "bin/workerd"
             },
@@ -1242,7 +1243,8 @@
             "version": "2.13.0",
             "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.0.tgz",
             "integrity": "sha512-mqVORhUJViA28fwHYaWmsXSzLO9osbdZ5ImUfxBarqsYdMlPbqAqGJCxsNzvppp1BEzc1mJNjOVvQqeDN8Vspw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@astrojs/internal-helpers": {
             "version": "0.7.5",
@@ -1398,12 +1400,14 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.3.0.tgz",
             "integrity": "sha512-W+Adw6ZA6mgvnSnhOki270rwJ42t4XzSK6YWGF//BbVXL6SwCLWfyzBc1lN2m/4RM28KubdBKQ4X5VMoLRNPQw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@better-fetch/fetch": {
             "version": "1.1.21",
             "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
-            "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="
+            "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==",
+            "peer": true
         },
         "node_modules/@capsizecss/unpack": {
             "version": "4.0.0",
@@ -1533,7 +1537,8 @@
             "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260114.0.tgz",
             "integrity": "sha512-Q3YG2tAPvN0Z9LueWZp8RyBIJYAppb2+knSh9WXagm/W6XERGKtYfMV0z9Ij5bJksmvvR/R9jTjjEqbK27kd8g==",
             "devOptional": true,
-            "license": "MIT OR Apache-2.0"
+            "license": "MIT OR Apache-2.0",
+            "peer": true
         },
         "node_modules/@cspotcode/source-map-support": {
             "version": "0.8.1",
@@ -3386,6 +3391,7 @@
             "resolved": "https://registry.npmjs.org/@libsql/client/-/client-0.17.0.tgz",
             "integrity": "sha512-TLjSU9Otdpq0SpKHl1tD1Nc9MKhrsZbCFGot3EbCxRa8m1E5R1mMwoOjKMMM31IyF7fr+hPNHLpYfwbMKNusmg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@libsql/core": "^0.17.0",
                 "@libsql/hrana-client": "^0.9.0",
@@ -4117,6 +4123,7 @@
             "integrity": "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
                 "debug": "^4.4.1",
@@ -4671,136 +4678,6 @@
                 "typescript": ">=4.8.4 <6.0.0"
             }
         },
-        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/project-service": {
-            "version": "8.53.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.53.1.tgz",
-            "integrity": "sha512-WYC4FB5Ra0xidsmlPb+1SsnaSKPmS3gsjIARwbEkHkoWloQmuzcfypljaJcR78uyLA1h8sHdWWPHSLDI+MtNog==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.53.1",
-                "@typescript-eslint/types": "^8.53.1",
-                "debug": "^4.4.3"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.8.4 <6.0.0"
-            }
-        },
-        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.53.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.53.1.tgz",
-            "integrity": "sha512-Lu23yw1uJMFY8cUeq7JlrizAgeQvWugNQzJp8C3x8Eo5Jw5Q2ykMdiiTB9vBVOOUBysMzmRRmUfwFrZuI2C4SQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/types": "8.53.1",
-                "@typescript-eslint/visitor-keys": "8.53.1"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.53.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.53.1.tgz",
-            "integrity": "sha512-qfvLXS6F6b1y43pnf0pPbXJ+YoXIC7HKg0UGZ27uMIemKMKA6XH2DTxsEDdpdN29D+vHV07x/pnlPNVLhdhWiA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.8.4 <6.0.0"
-            }
-        },
-        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
-            "version": "8.53.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.53.1.tgz",
-            "integrity": "sha512-jr/swrr2aRmUAUjW5/zQHbMaui//vQlsZcJKijZf3M26bnmLj8LyZUpj8/Rd6uzaek06OWsqdofN/Thenm5O8A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.53.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.53.1.tgz",
-            "integrity": "sha512-RGlVipGhQAG4GxV1s34O91cxQ/vWiHJTDHbXRr0li2q/BGg3RR/7NM8QDWgkEgrwQYCvmJV9ichIwyoKCQ+DTg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/project-service": "8.53.1",
-                "@typescript-eslint/tsconfig-utils": "8.53.1",
-                "@typescript-eslint/types": "8.53.1",
-                "@typescript-eslint/visitor-keys": "8.53.1",
-                "debug": "^4.4.3",
-                "minimatch": "^9.0.5",
-                "semver": "^7.7.3",
-                "tinyglobby": "^0.2.15",
-                "ts-api-utils": "^2.4.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.8.4 <6.0.0"
-            }
-        },
-        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.53.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.53.1.tgz",
-            "integrity": "sha512-oy+wV7xDKFPRyNggmXuZQSBzvoLnpmJs+GhzRhPjrxl2b/jIlyjVokzm47CZCDUdXKr2zd7ZLodPfOBpOPyPlg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/types": "8.53.1",
-                "eslint-visitor-keys": "^4.2.1"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
         "node_modules/@typescript-eslint/project-service": {
             "version": "8.53.1",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.53.1.tgz",
@@ -4991,6 +4868,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -5278,6 +5156,7 @@
             "resolved": "https://registry.npmjs.org/astro/-/astro-5.16.11.tgz",
             "integrity": "sha512-Z7kvkTTT5n6Hn5lCm6T3WU6pkxx84Hn25dtQ6dR7ATrBGq9eVa8EuB/h1S8xvaoVyCMZnIESu99Z9RJfdLRLDA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@astrojs/compiler": "^2.13.0",
                 "@astrojs/internal-helpers": "0.7.5",
@@ -5629,6 +5508,7 @@
             "version": "1.4.15",
             "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.4.15.tgz",
             "integrity": "sha512-uAvq8YA7SaS7v+TrvH/Kwt7LAJihzUqB3FX8VweDsqu3gn5t51M+Bve+V1vVWR9qBAtC6cN68V6b+scxZxDY4A==",
+            "peer": true,
             "dependencies": {
                 "@standard-schema/spec": "^1.0.0",
                 "zod": "^4.1.12"
@@ -5659,6 +5539,7 @@
             "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.1.8.tgz",
             "integrity": "sha512-XMQ2rs6FNXasGNfMjzbyroSwKwYbZ/T3IxruSS6U2MJRsSYh3wYtG3o6H00ZlKZ/C/UPOAD97tqgQJNsxyeTXw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@better-auth/utils": "^0.3.0",
                 "@better-fetch/fetch": "^1.1.4",
@@ -6637,6 +6518,7 @@
             "integrity": "sha512-O9EC/miwdnRDY10qRxM8P3Pg8hXe3LyU4ZipReKOgTwn4OqANmftj8XJz1UPUAS6NMHf0E2htjsbQujUTkncCg==",
             "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@drizzle-team/brocli": "^0.10.2",
                 "@esbuild-kit/esm-loader": "^2.5.5",
@@ -6652,6 +6534,7 @@
             "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.41.0.tgz",
             "integrity": "sha512-7A4ZxhHk9gdlXmTdPj/lREtP+3u8KvZ4yEN6MYVxBzZGex5Wtdc+CWSbu7btgF6TB0N+MNPrvW7RKBbxJchs/Q==",
             "license": "Apache-2.0",
+            "peer": true,
             "peerDependencies": {
                 "@aws-sdk/client-rds-data": ">=3",
                 "@cloudflare/workers-types": ">=4",
@@ -7018,6 +6901,7 @@
             "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
             "hasInstallScript": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -7095,6 +6979,7 @@
             "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -9023,6 +8908,7 @@
             "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
             "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/panva"
             }
@@ -9120,6 +9006,7 @@
             "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.9.tgz",
             "integrity": "sha512-3BeXMoiOhpOwu62CiVpO6lxfq4eS6KMYfQdMsN/2kUCRNuF2YiEr7u0HLHaQU+O4Xu8YXE3bHVkwaQ85i72EuA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20.0.0"
             }
@@ -10635,6 +10522,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^20.0.0 || >=22.0.0"
             }
@@ -11224,6 +11112,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -11357,6 +11246,7 @@
             "integrity": "sha512-yEPsovQfpxYfgWNhCfECjG5AQaO+K3dp6XERmOepyPDVqcJm+bjyCVO3pmU+nAPe0N5dDvekfGezt/EIiRe1TA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -11833,6 +11723,7 @@
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.54.0.tgz",
             "integrity": "sha512-3nk8Y3a9Ea8szgKhinMlGMhGMw89mqule3KWczxhIzqudyHdCIOHw8WJlj/r329fACjKLEh13ZSk7oE22kyeIw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.8"
             },
@@ -12586,6 +12477,7 @@
             "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.47.1.tgz",
             "integrity": "sha512-MhSWfWEpG5T57z0Oyfk9D1GhAz/KTZKZZlWtGEsy9zNk2fafpuU7sJQlXNSA8HtvwKxVC9XlDyl5YovXUXjjHA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jridgewell/remapping": "^2.3.4",
                 "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -12760,7 +12652,8 @@
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
             "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/tapable": {
             "version": "2.3.0",
@@ -13011,6 +12904,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -13030,31 +12924,6 @@
                 "@typescript-eslint/parser": "8.53.1",
                 "@typescript-eslint/typescript-estree": "8.53.1",
                 "@typescript-eslint/utils": "8.53.1"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
-            }
-        },
-        "node_modules/typescript-eslint/node_modules/@typescript-eslint/parser": {
-            "version": "8.53.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.53.0.tgz",
-            "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/scope-manager": "8.53.0",
-                "@typescript-eslint/types": "8.53.0",
-                "@typescript-eslint/typescript-estree": "8.53.0",
-                "@typescript-eslint/visitor-keys": "8.53.0",
-                "debug": "^4.4.3"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -13126,6 +12995,7 @@
             "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "pathe": "^2.0.3"
             }
@@ -13443,6 +13313,7 @@
             "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
             "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.4.4",
@@ -13733,6 +13604,7 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "workerd": "bin/workerd"
             },
@@ -14493,6 +14365,7 @@
             "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
             "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -88,7 +88,7 @@ const cache = {
     >(),
 };
 
-const CACHE_TTL = 3600000; // 1 hour in milliseconds
+const CACHE_TTL = 60 * 60 * 1000; // 1 hour in milliseconds
 
 function getCached<T>(entry: CacheEntry<T> | null): T | null {
     if (!entry) return null;

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -1,7 +1,13 @@
 import { defineAction, ActionError } from "astro:actions";
 import { z } from "astro:schema";
 import type { ProfilePatch } from "../library/types/interfaces";
-import { saveUserProfile as saveUserProfileServer } from "../library/server/bentoApi";
+import {
+    saveUserProfile as saveUserProfileServer,
+    fetchUsageStats,
+    fetchLeaderboardUsers,
+    fetchLeaderboardUsersForServer,
+} from "../library/server/bentoApi";
+import { getPatreonUsersWithRanks } from "../library/server/patreon";
 import type { BentoBetterAuthUser } from "../library/auth";
 
 // Build a strict Zod schema that mirrors ProfileDto, then derive a Patch schema
@@ -67,6 +73,33 @@ const ProfilePatchSchema: z.ZodType<ProfilePatch> = ProfileDtoSchema.partial().m
     z.object({ UserId: z.string().regex(/^\d+$/, "UserId must be a string of digits") })
 );
 
+// Server-side cache for data responses (1 hour TTL)
+interface CacheEntry<T> {
+    data: T;
+    expires: number;
+}
+
+const cache = {
+    stats: null as CacheEntry<Awaited<ReturnType<typeof fetchUsageStats>>> | null,
+    patreon: null as CacheEntry<Awaited<ReturnType<typeof getPatreonUsersWithRanks>>> | null,
+    leaderboard: new Map<
+        string,
+        CacheEntry<Awaited<ReturnType<typeof fetchLeaderboardUsers>>>
+    >(),
+};
+
+const CACHE_TTL = 3600000; // 1 hour in milliseconds
+
+function getCached<T>(entry: CacheEntry<T> | null): T | null {
+    if (!entry) return null;
+    if (entry.expires < Date.now()) return null;
+    return entry.data;
+}
+
+function setCached<T>(data: T): CacheEntry<T> {
+    return { data, expires: Date.now() + CACHE_TTL };
+}
+
 export const server = {
     saveProfile: defineAction({
         input: ProfilePatchSchema,
@@ -97,6 +130,46 @@ export const server = {
 
             await saveUserProfileServer(input);
             return null;
+        },
+    }),
+
+    getUsageStats: defineAction({
+        handler: async () => {
+            const cached = getCached(cache.stats);
+            if (cached) return cached;
+
+            const data = await fetchUsageStats();
+            cache.stats = setCached(data);
+            return data;
+        },
+    }),
+
+    getPatreonUsers: defineAction({
+        handler: async () => {
+            const cached = getCached(cache.patreon);
+            if (cached) return cached;
+
+            const data = await getPatreonUsersWithRanks();
+            cache.patreon = setCached(data);
+            return data;
+        },
+    }),
+
+    getLeaderboard: defineAction({
+        input: z.object({
+            serverId: z.string().optional(),
+        }),
+        handler: async (input) => {
+            const cacheKey = input.serverId || "global";
+            const cached = getCached(cache.leaderboard.get(cacheKey) || null);
+            if (cached) return cached;
+
+            const data = input.serverId
+                ? await fetchLeaderboardUsersForServer(input.serverId)
+                : await fetchLeaderboardUsers();
+
+            cache.leaderboard.set(cacheKey, setCached(data));
+            return data;
         },
     }),
 };

--- a/src/components/app/UserMenu.svelte
+++ b/src/components/app/UserMenu.svelte
@@ -11,7 +11,7 @@
     const { user = null } = $props<{ user: BentoBetterAuthUser | null }>();
 
     const sessionStore = svelteAuthClient.useSession();
-    const currentUser = $derived.by(() => user ?? sessionStore?.value?.data?.user ?? null);
+    const currentUser = $derived.by(() => sessionStore?.value?.data?.user ?? user ?? null);
 
     let open = $state(false);
     let menuElement: HTMLDivElement | null = $state(null);

--- a/src/components/homepage/Stats.svelte
+++ b/src/components/homepage/Stats.svelte
@@ -1,0 +1,133 @@
+<script lang="ts">
+    import { actions } from "astro:actions";
+    import { onMount } from "svelte";
+    import { FormatThousands } from "../../library/utils";
+
+    let stats = $state<{ userCount: number; serverCount: number } | null>(null);
+    let loading = $state(true);
+    let error = $state<string | null>(null);
+
+    onMount(async () => {
+        try {
+            const { data } = await actions.getUsageStats();
+            if (data) {
+                stats = data;
+            }
+        } catch (e) {
+            console.error("Failed to fetch usage stats:", e);
+            error = e instanceof Error ? e.message : "Failed to load stats";
+        } finally {
+            loading = false;
+        }
+    });
+
+    const users = $derived(stats ? FormatThousands(stats.userCount - 763) : "0");
+    const servers = $derived(stats ? Math.max(0, stats.serverCount - 7) : 0);
+</script>
+
+{#if loading}
+    <!-- Skeleton loader -->
+    <div class="mt-10 pb-1">
+        <div class="relative">
+            <div class="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                <div class="max-w-4xl mx-auto">
+                    <dl class="sm:grid sm:grid-cols-3">
+                        <div class="flex flex-col p-6 text-center">
+                            <dt
+                                class="order-2 mt-2 text-lg leading-6 font-medium dark:text-white text-black"
+                            >
+                                Servers
+                            </dt>
+                            <div class="flex gap-x-2 justify-center items-center h-12">
+                                <span class="sr-only">Loading...</span>
+                                <div
+                                    class="h-6 w-6 dark:bg-white bg-black rounded-full animate-bounce [animation-delay:-0.3s]"
+                                ></div>
+                                <div
+                                    class="h-6 w-6 dark:bg-white bg-black rounded-full animate-bounce [animation-delay:-0.15s]"
+                                ></div>
+                                <div
+                                    class="h-6 w-6 dark:bg-white bg-black rounded-full animate-bounce"
+                                ></div>
+                            </div>
+                        </div>
+                        <div class="flex flex-col p-6 text-center">
+                            <dt
+                                class="order-2 mt-2 text-lg leading-6 font-medium dark:text-white text-black"
+                            >
+                                Users
+                            </dt>
+                            <div class="flex gap-x-2 justify-center items-center h-12">
+                                <span class="sr-only">Loading...</span>
+                                <div
+                                    class="h-6 w-6 dark:bg-white bg-black rounded-full animate-bounce [animation-delay:-0.3s]"
+                                ></div>
+                                <div
+                                    class="h-6 w-6 dark:bg-white bg-black rounded-full animate-bounce [animation-delay:-0.15s]"
+                                ></div>
+                                <div
+                                    class="h-6 w-6 dark:bg-white bg-black rounded-full animate-bounce"
+                                ></div>
+                            </div>
+                        </div>
+                        <div class="flex flex-col p-6 text-center">
+                            <dt
+                                class="order-2 mt-2 text-lg leading-6 font-medium dark:text-white text-black"
+                            >
+                                Serving the first Bento
+                            </dt>
+                            <dd class="order-1 text-5xl font-extrabold dark:text-white text-black">
+                                Aug 2021
+                            </dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+        </div>
+    </div>
+{:else if error}
+    <div class="mt-10 pb-1 text-center">
+        <p class="text-red-500 dark:text-red-400">Failed to load stats</p>
+    </div>
+{:else if stats}
+    <div class="mt-10 pb-1">
+        <div class="relative">
+            <div class="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                <div class="max-w-4xl mx-auto">
+                    <dl class="sm:grid sm:grid-cols-3">
+                        <div class="flex flex-col p-6 text-center">
+                            <dt
+                                class="order-2 mt-2 text-lg leading-6 font-medium dark:text-white text-black"
+                            >
+                                Servers
+                            </dt>
+                            <dd class="order-1 text-5xl font-extrabold dark:text-white text-black">
+                                {servers}
+                            </dd>
+                        </div>
+                        <div class="flex flex-col p-6 text-center">
+                            <dt
+                                class="order-2 mt-2 text-lg leading-6 font-medium dark:text-white text-black"
+                            >
+                                Users
+                            </dt>
+                            <dd class="order-1 text-5xl font-extrabold dark:text-white text-black">
+                                {users}
+                            </dd>
+                        </div>
+                        <div class="flex flex-col p-6 text-center">
+                            <dt
+                                class="order-2 mt-2 text-lg leading-6 font-medium dark:text-white text-black"
+                            >
+                                Serving the first Bento
+                            </dt>
+                            <dd class="order-1 text-5xl font-extrabold dark:text-white text-black">
+                                Aug 2021
+                            </dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+        </div>
+    </div>
+{/if}

--- a/src/components/leaderboard/Leaderboard.svelte
+++ b/src/components/leaderboard/Leaderboard.svelte
@@ -4,7 +4,7 @@
     import type { LeaderboardResponseDto } from "../../library/types/interfaces";
     import LeaderboardUser from "./LeaderboardUser.svelte";
 
-    const { serverId } = $props<{ serverId?: string }>();
+    const { serverId } = $props<{ serverId: string | undefined }>();
 
     let rankings = $state<LeaderboardResponseDto | null>(null);
     let loading = $state(true);
@@ -30,7 +30,7 @@
     <div class="max-w-(--breakpoint-2xl) mx-auto px-3 pt-2">
         <div class="h-8 bg-zinc-300 dark:bg-zinc-700 rounded w-64 mx-auto mb-8 animate-pulse"></div>
         <ul class="relative">
-            {#each [1, 2, 3] as _}
+            {#each [1, 2, 3] as _, i (i)}
                 <li
                     class="transition duration-300 ease-in-out dark:bg-zinc-900 bg-zinc-100 flex items-center w-full my-4 p-2 px-4 rounded-lg shadow-xs overflow-hidden animate-pulse"
                 >
@@ -116,7 +116,7 @@
     {/if}
     <div class="max-w-(--breakpoint-2xl) mx-auto px-3 pt-2">
         <ul class="relative">
-            {#each rankings.users || [] as discordUser}
+            {#each rankings.users || [] as discordUser (discordUser.userId)}
                 <div class="shadow-lg">
                     <LeaderboardUser {...discordUser} />
                 </div>

--- a/src/components/leaderboard/Leaderboard.svelte
+++ b/src/components/leaderboard/Leaderboard.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+    import { actions } from "astro:actions";
+    import { onMount } from "svelte";
+    import type { LeaderboardResponseDto } from "../../library/types/interfaces";
+    import LeaderboardUser from "./LeaderboardUser.svelte";
+
+    const { serverId } = $props<{ serverId?: string }>();
+
+    let rankings = $state<LeaderboardResponseDto | null>(null);
+    let loading = $state(true);
+    let error = $state<string | null>(null);
+
+    onMount(async () => {
+        try {
+            const { data } = await actions.getLeaderboard({ serverId });
+            if (data) {
+                rankings = data;
+            }
+        } catch (e) {
+            console.error("Error fetching leaderboard data:", e);
+            error = e instanceof Error ? e.message : "An unknown error occurred";
+        } finally {
+            loading = false;
+        }
+    });
+</script>
+
+{#if loading}
+    <!-- Skeleton loader -->
+    <div class="max-w-(--breakpoint-2xl) mx-auto px-3 pt-2">
+        <div class="h-8 bg-zinc-300 dark:bg-zinc-700 rounded w-64 mx-auto mb-8 animate-pulse"></div>
+        <ul class="relative">
+            {#each [1, 2, 3] as _}
+                <li
+                    class="transition duration-300 ease-in-out dark:bg-zinc-900 bg-zinc-100 flex items-center w-full my-4 p-2 px-4 rounded-lg shadow-xs overflow-hidden animate-pulse"
+                >
+                    <div class="shrink-0 w-72 truncate text-left flex items-center">
+                        <div
+                            class="inline-block dark:bg-zinc-800 bg-zinc-200 px-2 py-1 rounded-md w-8 h-6"
+                        ></div>
+                        <div class="w-16 h-16 rounded-full bg-zinc-300 dark:bg-zinc-700 mx-4"></div>
+                        <div class="h-4 bg-zinc-300 dark:bg-zinc-700 rounded w-32"></div>
+                    </div>
+                    <div class="grow p-4 w-full md:w-auto">
+                        <div class="h-1 bg-zinc-300 dark:bg-zinc-700 rounded w-full"></div>
+                    </div>
+                    <div class="p-4 h-20 flex md:w-auto items-center">
+                        <div class="h-8 w-16 bg-zinc-300 dark:bg-zinc-700 rounded"></div>
+                    </div>
+                </li>
+            {/each}
+        </ul>
+    </div>
+{:else if error}
+    <div class="max-w-(--breakpoint-2xl) mx-auto px-3 pt-2">
+        <div
+            class="transition duration-300 ease-in-out dark:bg-zinc-900 bg-zinc-100 flex items-center w-full my-4 p-4 px-6 rounded-lg hover:bg-zinc-200 dark:hover:bg-zinc-800 shadow-lg overflow-hidden group"
+            role="alert"
+        >
+            <div class="shrink-0 mr-4">
+                <div
+                    class="transition duration-300 ease-in-out inline-block dark:bg-zinc-700 bg-zinc-300 p-3 rounded-md dark:group-hover:bg-zinc-600 group-hover:bg-zinc-400"
+                >
+                    <svg
+                        class="h-6 w-6 dark:text-zinc-300 text-zinc-700"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                    >
+                        <path
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                            d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                        ></path>
+                    </svg>
+                </div>
+            </div>
+            <div class="grow">
+                <h1
+                    class="transition duration-300 ease-in-out dark:text-zinc-200 dark:group-hover:text-white text-zinc-800 group-hover:text-zinc-900 font-bold"
+                >
+                    Error
+                </h1>
+                <p
+                    class="transition duration-300 ease-in-out dark:text-zinc-400 dark:group-hover:text-zinc-300 text-zinc-600 group-hover:text-zinc-700"
+                >
+                    Invalid Server ID for the leaderboard page
+                </p>
+                <p
+                    class="transition duration-300 ease-in-out dark:text-zinc-500 dark:group-hover:text-zinc-400 text-zinc-500 group-hover:text-zinc-600 mt-2"
+                >
+                    Please check if the server ID is correct and try again.
+                </p>
+            </div>
+        </div>
+    </div>
+{:else if rankings}
+    <h1
+        class="mt-2 text-3xl leading-8 font-extrabold tracking-tight dark:text-white text-black sm:text-4xl text-center"
+    >
+        Leaderboard for {rankings.guildName ?? "Bento"}
+    </h1>
+    {#if serverId && rankings.icon}
+        <div
+            class="dark:bg-zinc-900/50 bg-zinc-100/50 mx-auto my-auto p-1 mt-8 w-64 rounded-sm shadow-lg"
+        >
+            <img
+                width={256}
+                height={256}
+                class="mx-auto shadow-lg dark:bg-zinc-800 bg-zinc-200"
+                src={rankings.icon}
+                alt="Server Icon"
+            />
+        </div>
+    {/if}
+    <div class="max-w-(--breakpoint-2xl) mx-auto px-3 pt-2">
+        <ul class="relative">
+            {#each rankings.users || [] as discordUser}
+                <div class="shadow-lg">
+                    <LeaderboardUser {...discordUser} />
+                </div>
+            {/each}
+        </ul>
+    </div>
+{/if}

--- a/src/components/leaderboard/LeaderboardUser.svelte
+++ b/src/components/leaderboard/LeaderboardUser.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+    const rankToStyle = (rank: number) => {
+        switch (rank) {
+            case 1:
+                return { color: "#FFD700", fontWeight: 1000 };
+            case 2:
+                return { color: "#C0C0C0", fontWeight: 700 };
+            case 3:
+                return { color: "#CD7F32", fontWeight: 500 };
+            default:
+                return {};
+        }
+    };
+
+    const { rank, level, xp, avatarUrl, username, discriminator } = $props<{
+        rank: number;
+        level: number;
+        xp: number;
+        userId: bigint;
+        avatarUrl: string;
+        username: string;
+        discriminator: string;
+    }>();
+
+    const rankNumber = $derived(Number(rank));
+    const topUsersStyle = $derived(rankToStyle(rankNumber));
+    const percent = $derived((xp / (level * level * 100)) * 100);
+    const truncatedDiscriminator = $derived(("0000" + discriminator).slice(-4));
+    const messagesToNextLevel = $derived(Math.round((level * level * 100 - xp) / 46));
+
+    const styleString = $derived(
+        Object.entries(topUsersStyle)
+            .map(([key, value]) => `${key.replace(/([A-Z])/g, "-$1").toLowerCase()}: ${value}`)
+            .join("; ")
+    );
+</script>
+
+<li
+    class="transition duration-300 ease-in-out dark:bg-zinc-900 bg-zinc-100 flex items-center w-full my-4 p-2 px-4 rounded-lg group hover:bg-zinc-200 dark:hover:bg-zinc-800 shadow-xs overflow-hidden"
+>
+    <div class="shrink-0 w-72 truncate dark:text-zinc-700 text-zinc-100 text-left">
+        <div
+            class="transition duration-300 ease-in-out inline-block dark:bg-zinc-800 bg-zinc-200 px-2 py-1 rounded-md dark:group-hover:bg-zinc-900 group-hover:bg-zinc-300"
+        >
+            <span
+                class="transition duration-300 ease-in-out dark:text-zinc-400 dark:group-hover:text-zinc-400 text-zinc-950 group-hover:text-zinc-950 bg-clip-text"
+                style={styleString}
+            >
+                {rankNumber}
+            </span>
+        </div>
+        <img
+            class="w-16 dark:bg-zinc-800 bg-zinc-200 rounded-full inline-block mx-4 whitespace-nowrap overflow-hidden"
+            src={avatarUrl}
+            alt="{username}'s Avatar"
+            style="text-indent: 100%;"
+            width={64}
+            height={64}
+        />
+        <span
+            title="{username}#{truncatedDiscriminator}"
+            class="transition duration-300 ease-in-out text-zinc-400 group-hover:text-zinc-400"
+        >
+            <span
+                class="transition duration-300 ease-in-out dark:text-zinc-200 dark:group-hover:text-white text-zinc-800 group-hover:text-black"
+            >
+                {username}
+            </span>
+            <span>#{truncatedDiscriminator}</span>
+        </span>
+    </div>
+
+    <div class="grow p-4 w-full md:w-auto overflow-hidden">
+        <div
+            class="max-lg:hidden transition duration-1000 ease-in-out dark:text-white text-black text-left opacity-0 group-hover:opacity-100 overflow-hidden"
+        >
+            {messagesToNextLevel} messages to level {level + 1}
+        </div>
+        <div
+            title="{messagesToNextLevel} messages to level {level + 1}"
+            class="transition duration-300 ease-in-out mt-1 mb-1 w-full h-1 dark:bg-zinc-700 dark:group-hover:bg-zinc-500 bg-zinc-300 group-hover:bg-zinc-400 rounded-sm overflow-hidden"
+        >
+            <div class="progress-done" style="opacity: 0.75; width: {percent}%;"></div>
+        </div>
+    </div>
+
+    <div
+        class="dark:text-white text-black p-4 h-20 flex md:w-auto items-center justify-between"
+    >
+        <div>
+            Level
+            <br />
+            <span class="text-2xl font-medium">{level}</span>
+        </div>
+    </div>
+</li>

--- a/src/components/patreon/Patreon.svelte
+++ b/src/components/patreon/Patreon.svelte
@@ -88,13 +88,13 @@
     {#each categories as category}
         {#if category.data.length > 0}
             <div class="max-w-(--breakpoint-2xl) mx-auto px-3 pt-2">
-                <div
-                    class="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400 text-center mb-4"
+                <h2
+                    class="mt-2 text-2xl leading-7 font-semibold text-yellow-400 dark:text-yellow-300 text-center"
                 >
                     {category.data.length > 1
                         ? `Bento ${category.label}s`
                         : `Bento ${category.label}`}
-                </div>
+                </h2>
                 <ul class="block flex-wrap mx-auto text-center w-full">
                     {#each category.data as patreonUser}
                         <div class="mx-auto inline-block p-1 w-full sm:w-auto">

--- a/src/components/patreon/Patreon.svelte
+++ b/src/components/patreon/Patreon.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+    import { actions } from "astro:actions";
+    import { onMount } from "svelte";
+    import type { PatreonsByTier } from "../../library/server/patreon";
+    import PatreonUser from "./PatreonUser.svelte";
+
+    let patreons = $state<PatreonsByTier | null>(null);
+    let loading = $state(true);
+    let error = $state<string | null>(null);
+
+    onMount(async () => {
+        try {
+            const { data } = await actions.getPatreonUsers();
+            if (data) {
+                patreons = data;
+            }
+        } catch (e) {
+            console.error("Failed to fetch patreon users:", e);
+            error = e instanceof Error ? e.message : "Failed to load patreon supporters";
+        } finally {
+            loading = false;
+        }
+    });
+
+    const categories = $derived(
+        patreons
+            ? [
+                  { data: patreons.sponsors, label: "Sponsor" },
+                  { data: patreons.disciples, label: "Disciple" },
+                  { data: patreons.enthusiasts, label: "Enthusiast" },
+                  { data: patreons.followers, label: "Follower" },
+                  { data: patreons.supporters, label: "Supporter" },
+              ]
+            : []
+    );
+
+    const areAllCategoriesEmpty = $derived(
+        categories.every((category) => category.data.length === 0)
+    );
+</script>
+
+{#if loading}
+    <!-- Skeleton loader -->
+    <div class="max-w-(--breakpoint-2xl) mx-auto px-3 pt-2">
+        <div
+            class="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400 text-center mb-4"
+        >
+            Patreon Tier
+        </div>
+        <ul class="block flex-wrap mx-auto text-center w-full">
+            <div class="mx-auto inline-block p-1 w-full sm:w-auto">
+                <div
+                    class="transition duration-300 ease-in-out dark:bg-zinc-900 bg-zinc-100 flex flex-wrap items-center w-full sm:w-96 my-4 px-4 rounded-lg shadow-xs overflow-hidden animate-pulse"
+                >
+                    <div class="shrink-0 truncate text-left py-5 mx-auto">
+                        <div class="rounded-full bg-zinc-300 dark:bg-zinc-700 w-20 h-20 mx-4"></div>
+                    </div>
+                    <div class="grow p-4 w-full md:w-auto overflow-hidden">
+                        <div class="h-6 bg-zinc-300 dark:bg-zinc-700 rounded w-32 mx-auto lg:mx-0">
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </ul>
+    </div>
+{:else if error}
+    <div class="max-w-(--breakpoint-2xl) mx-auto px-3 pt-2 text-center">
+        <p class="text-red-500 dark:text-red-400">Failed to load patreon supporters</p>
+    </div>
+{:else if areAllCategoriesEmpty}
+    <div class="max-w-(--breakpoint-2xl) mx-auto px-3 pt-2">
+        <p class="mt-4 max-w-2xl text-xl text-zinc-300 lg:mx-auto text-center mx-auto">
+            Other than the awesome users who support by using Bento 🍱
+            <br />
+            no <strong>Patrons</strong> on
+            <a
+                href="https://www.patreon.com/bentobot"
+                target="_blank"
+                rel="noreferrer"
+                class="text-patreon hover:underline"
+            >
+                Patreon
+            </a>
+            at the moment.
+        </p>
+    </div>
+{:else}
+    {#each categories as category}
+        {#if category.data.length > 0}
+            <div class="max-w-(--breakpoint-2xl) mx-auto px-3 pt-2">
+                <div
+                    class="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400 text-center mb-4"
+                >
+                    {category.data.length > 1
+                        ? `Bento ${category.label}s`
+                        : `Bento ${category.label}`}
+                </div>
+                <ul class="block flex-wrap mx-auto text-center w-full">
+                    {#each category.data as patreonUser}
+                        <div class="mx-auto inline-block p-1 w-full sm:w-auto">
+                            <PatreonUser user={patreonUser} />
+                        </div>
+                    {/each}
+                </ul>
+            </div>
+        {/if}
+    {/each}
+{/if}

--- a/src/components/patreon/Patreon.svelte
+++ b/src/components/patreon/Patreon.svelte
@@ -48,7 +48,7 @@
             Patreon Tier
         </div>
         <ul class="block flex-wrap mx-auto text-center w-full">
-            <div class="mx-auto inline-block p-1 w-full sm:w-auto">
+            <li class="mx-auto inline-block p-1 w-full sm:w-auto">
                 <div
                     class="transition duration-300 ease-in-out dark:bg-zinc-900 bg-zinc-100 flex flex-wrap items-center w-full sm:w-96 my-4 px-4 rounded-lg shadow-xs overflow-hidden animate-pulse"
                 >
@@ -60,7 +60,7 @@
                         </div>
                     </div>
                 </div>
-            </div>
+            </li>
         </ul>
     </div>
 {:else if error}
@@ -85,7 +85,7 @@
         </p>
     </div>
 {:else}
-    {#each categories as category}
+    {#each categories as category (category.label)}
         {#if category.data.length > 0}
             <div class="max-w-(--breakpoint-2xl) mx-auto px-3 pt-2">
                 <h2
@@ -96,10 +96,10 @@
                         : `Bento ${category.label}`}
                 </h2>
                 <ul class="block flex-wrap mx-auto text-center w-full">
-                    {#each category.data as patreonUser}
-                        <div class="mx-auto inline-block p-1 w-full sm:w-auto">
+                    {#each category.data as patreonUser (patreonUser.userId)}
+                        <li class="mx-auto inline-block p-1 w-full sm:w-auto">
                             <PatreonUser user={patreonUser} />
-                        </div>
+                        </li>
                     {/each}
                 </ul>
             </div>

--- a/src/components/patreon/PatreonUser.svelte
+++ b/src/components/patreon/PatreonUser.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+    import type { PatreonWithRank } from "../../library/server/patreon";
+
+    interface RankStyle {
+        width: string;
+        avatarWidth: number | { mobile: number; desktop: number };
+        avatarHeight: number | { mobile: number; desktop: number };
+        textSize: string;
+    }
+
+    const rankStyles: Record<number, RankStyle> = {
+        1: {
+            width: "w-full sm:w-96",
+            avatarWidth: { mobile: 80, desktop: 125 },
+            avatarHeight: { mobile: 80, desktop: 125 },
+            textSize: "text-xl",
+        },
+        2: {
+            width: "w-full sm:w-96",
+            avatarWidth: { mobile: 70, desktop: 100 },
+            avatarHeight: { mobile: 70, desktop: 100 },
+            textSize: "text-lg",
+        },
+        3: {
+            width: "w-full sm:w-96",
+            avatarWidth: { mobile: 60, desktop: 75 },
+            avatarHeight: { mobile: 60, desktop: 75 },
+            textSize: "text-base",
+        },
+        4: {
+            width: "w-full sm:w-96",
+            avatarWidth: { mobile: 40, desktop: 50 },
+            avatarHeight: { mobile: 40, desktop: 50 },
+            textSize: "text-sm",
+        },
+        5: {
+            width: "w-full sm:w-96",
+            avatarWidth: { mobile: 20, desktop: 25 },
+            avatarHeight: { mobile: 20, desktop: 25 },
+            textSize: "text-xs",
+        },
+    };
+
+    const { user } = $props<{ user: PatreonWithRank }>();
+
+    const style = $derived(rankStyles[user.rank] || rankStyles[5]!);
+
+    const avatarWidthStyle = $derived(
+        typeof style.avatarWidth === "number"
+            ? `${style.avatarWidth}px`
+            : `clamp(${style.avatarWidth.mobile}px, 5vw + ${style.avatarWidth.mobile * 0.5}px, ${style.avatarWidth.desktop}px)`
+    );
+
+    const avatarHeightStyle = $derived(
+        typeof style.avatarHeight === "number"
+            ? `${style.avatarHeight}px`
+            : `clamp(${style.avatarHeight.mobile}px, 5vw + ${style.avatarHeight.mobile * 0.5}px, ${style.avatarHeight.desktop}px)`
+    );
+
+    const avatarWidth = $derived(
+        typeof style.avatarWidth === "number" ? style.avatarWidth : style.avatarWidth.desktop
+    );
+
+    const avatarHeight = $derived(
+        typeof style.avatarHeight === "number" ? style.avatarHeight : style.avatarHeight.desktop
+    );
+</script>
+
+<div>
+    <li
+        class="transition duration-300 ease-in-out dark:bg-zinc-900 bg-zinc-100 flex flex-wrap items-center {style.width} my-4 px-4 rounded-lg group hover:bg-zinc-200 dark:hover:bg-zinc-800 shadow-xs overflow-hidden"
+    >
+        <div class="shrink-0 truncate text-left py-5 mx-auto">
+            <img
+                width={avatarWidth}
+                height={avatarHeight}
+                class="rounded-full inline-block mx-4 whitespace-nowrap overflow-hidden"
+                style="width: {avatarWidthStyle}; height: {avatarHeightStyle};"
+                src={user.avatarUrl}
+                alt="{user.name}'s Avatar"
+            />
+        </div>
+        <div class="grow p-4 w-full md:w-auto overflow-hidden">
+            <div
+                class="transition duration-1000 ease-in-out text-black dark:text-white text-center lg:text-left overflow-hidden {style.textSize}"
+            >
+                {user.name}
+            </div>
+        </div>
+    </li>
+</div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,21 +1,13 @@
 ---
 import SectionWrapper from "../layouts/SectionWrapper.astro";
 import AppLayout from "../layouts/app/AppLayout.astro";
-import Stats from "../components/homepage/Stats.astro";
-import StatsSkeleton from "../components/homepage/StatsSkeleton.astro";
+import Stats from "../components/homepage/Stats.svelte";
 import Waves from "../components/homepage/Waves.astro";
 import FeatureImagePreview, {
     type FeatureImagePreviewProps,
     type Feature,
 } from "../components/homepage/FeatureImagePreview.astro";
 
-Astro.response.headers.set("Cache-Control", "public, max-age=3600");
-
-Astro.response.headers.set(
-    "CDN-Cache-Control",
-    // cache for 1 hour
-    "public, max-age=3600"
-);
 
 const features: Feature[] = [
     {
@@ -149,9 +141,7 @@ const featurePreview: FeatureImagePreviewProps = {
                 </div>
             </SectionWrapper>
             <SectionWrapper>
-                <Stats server:defer>
-                    <StatsSkeleton slot="fallback" />
-                </Stats>
+                <Stats client:load />
             </SectionWrapper>
             <Waves />
         </div>

--- a/src/pages/leaderboard/[serverId].astro
+++ b/src/pages/leaderboard/[serverId].astro
@@ -14,7 +14,7 @@ const { serverId } = Astro.params;
     <SectionWrapper>
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="lg:text-center text-center overflow-hidden">
-                <Leaderboard {...(serverId ? { serverId } : {})} client:load />
+                <Leaderboard {serverId} client:load />
             </div>
         </div>
     </SectionWrapper>

--- a/src/pages/leaderboard/[serverId].astro
+++ b/src/pages/leaderboard/[serverId].astro
@@ -1,22 +1,10 @@
 ---
-import Leaderboard from "../../components/leaderboard/Leaderboard.astro";
+import Leaderboard from "../../components/leaderboard/Leaderboard.svelte";
 import AppLayout from "../../layouts/app/AppLayout.astro";
-import LeaderboardSkeleton from "../../components/leaderboard/LeaderboardSkeleton.astro";
 import SectionWrapper from "../../layouts/SectionWrapper.astro";
 
 const { serverId } = Astro.params;
 
-Astro.response.headers.set(
-    "Cache-Control",
-    // cache for 1 hour
-    "public, max-age=3600"
-);
-
-Astro.response.headers.set(
-    "CDN-Cache-Control",
-    // cache for 1 hour
-    "public, max-age=3600"
-);
 ---
 
 <AppLayout
@@ -26,9 +14,7 @@ Astro.response.headers.set(
     <SectionWrapper>
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="lg:text-center text-center overflow-hidden">
-                <Leaderboard serverId={serverId} server:defer>
-                    <LeaderboardSkeleton slot="fallback" serverId={serverId} />
-                </Leaderboard>
+                <Leaderboard {...(serverId ? { serverId } : {})} client:load />
             </div>
         </div>
     </SectionWrapper>

--- a/src/pages/leaderboard/index.astro
+++ b/src/pages/leaderboard/index.astro
@@ -1,26 +1,7 @@
 ---
-import Leaderboard from "../../components/leaderboard/Leaderboard.astro";
+import Leaderboard from "../../components/leaderboard/Leaderboard.svelte";
 import SectionWrapper from "../../layouts/SectionWrapper.astro";
 import AppLayout from "../../layouts/app/AppLayout.astro";
-import LeaderboardSkeleton from "../../components/leaderboard/LeaderboardSkeleton.astro";
-
-Astro.response.headers.set(
-    "Cache-Control",
-    // cache for 1 hour
-    "public, max-age=3600"
-);
-
-Astro.response.headers.set(
-    "CDN-Cache-Control",
-    // cache for 1 hour
-    "public, max-age=3600"
-);
-
-Astro.response.headers.set(
-    "CDN-Cache-Control",
-    // cache for 1 hour
-    "public, max-age=3600"
-);
 ---
 
 <AppLayout
@@ -30,9 +11,7 @@ Astro.response.headers.set(
     <SectionWrapper>
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="lg:text-center text-center overflow-hidden">
-                <Leaderboard server:defer>
-                    <LeaderboardSkeleton slot="fallback" />
-                </Leaderboard>
+                <Leaderboard client:load />
             </div>
         </div>
     </SectionWrapper>

--- a/src/pages/support.astro
+++ b/src/pages/support.astro
@@ -3,20 +3,7 @@ import AppLayout from "../layouts/app/AppLayout.astro";
 import Header from "../layouts/Header.astro";
 import SectionWrapper from "../layouts/SectionWrapper.astro";
 import Paragraph from "../layouts/Paragraph.astro";
-import Patreon from "../components/patreon/Patreon.astro";
-import PatreonSkeleton from "../components/patreon/PatreonSkeleton.astro";
-
-Astro.response.headers.set(
-    "Cache-Control",
-    // cache for 1 hour
-    "public, max-age=3600"
-);
-
-Astro.response.headers.set(
-    "CDN-Cache-Control",
-    // cache for 1 hour
-    "public, max-age=3600"
-);
+import Patreon from "../components/patreon/Patreon.svelte";
 ---
 
 <AppLayout
@@ -27,9 +14,7 @@ Astro.response.headers.set(
         <Header>
             Who supports <span class="text-yellow-400">Bento</span>?
         </Header>
-        <Patreon server:defer>
-            <PatreonSkeleton slot="fallback" />
-        </Patreon>
+        <Patreon client:load />
     </SectionWrapper>
     <SectionWrapper border>
         <Header>


### PR DESCRIPTION
- Converted leaderboard and Patreon components from Astro to Svelte for improved interactivity and maintainability.
- Introduced caching for server-side data (1-hour TTL) to optimize leaderboard and Patreon-related API calls.
- Simplified handling of stats and leaderboard rendering with `client:load`.
- Updated `UserMenu` logic for more reliable current user retrieval.