### PR TITLE
feat: server leaderboard access control

### DIFF
--- a/src/library/types/interfaces.ts
+++ b/src/library/types/interfaces.ts
@@ -86,6 +86,20 @@ export interface ProfileDto {
     XpBar2Colour: string | null;
 }
 
+export type LeaderboardDenialReason = "not_bot_user" | "not_member";
+
+export interface AuthorizedLeaderboardResult {
+    authorized: true;
+    data: LeaderboardResponseDto;
+}
+
+export interface DeniedLeaderboardResult {
+    authorized: false;
+    reason: LeaderboardDenialReason;
+}
+
+export type LeaderboardAccessResult = AuthorizedLeaderboardResult | DeniedLeaderboardResult;
+
 type PartialWithUndefined<T> = { [K in keyof T]?: T[K] | undefined };
 
 export type ProfilePatch = PartialWithUndefined<ProfileDto> & { UserId: string };

--- a/src/pages/leaderboard/[serverId].astro
+++ b/src/pages/leaderboard/[serverId].astro
@@ -1,14 +1,32 @@
 ---
-import Leaderboard from "../../components/leaderboard/Leaderboard.astro";
-import LeaderboardSkeleton from "../../components/leaderboard/LeaderboardSkeleton.astro";
+import LeaderboardUser from "../../components/leaderboard/LeaderboardUser.astro";
 import AppLayout from "../../layouts/app/AppLayout.astro";
 import SectionWrapper from "../../layouts/SectionWrapper.astro";
+import SignInButton from "../../components/auth/SignInButton.svelte";
+import type { BentoBetterAuthUser } from "../../library/auth";
+import { fetchAuthorizedLeaderboard } from "../../library/server/bentoApi";
+import type { LeaderboardAccessResult } from "../../library/types/interfaces";
+import { Icon } from "astro-icon/components";
 
 const { serverId } = Astro.params;
+const user = Astro.locals.user as BentoBetterAuthUser | null;
 
-Astro.response.headers.set("Cache-Control", "public, max-age=3600");
-Astro.response.headers.set("CDN-Cache-Control", "public, max-age=3600");
-Astro.response.headers.set("Vary", "Cookie");
+let result: LeaderboardAccessResult | null = null;
+let errorMessage: string | undefined;
+
+if (user && serverId) {
+    try {
+        result = await fetchAuthorizedLeaderboard(serverId, user.discordId);
+        if (result.authorized) {
+            Astro.response.headers.set("Cache-Control", "private, max-age=3600");
+            Astro.response.headers.set("CDN-Cache-Control", "private, max-age=3600");
+            Astro.response.headers.set("Vary", "Cookie");
+        }
+    } catch (error) {
+        console.error("Error fetching leaderboard data:", error);
+        errorMessage = error instanceof Error ? error.message : "An unknown error occurred";
+    }
+}
 ---
 
 <AppLayout
@@ -18,9 +36,107 @@ Astro.response.headers.set("Vary", "Cookie");
     <SectionWrapper>
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="lg:text-center text-center overflow-hidden">
-                <Leaderboard serverId={serverId} server:defer>
-                    <LeaderboardSkeleton slot="fallback" serverId={serverId} />
-                </Leaderboard>
+                {/** Not signed in **/}
+                {
+                    !user && (
+                        <div class="text-center py-10 bg-zinc-100 dark:bg-zinc-900 rounded-lg shadow">
+                            <p class="text-gray-700 dark:text-gray-300 mb-4">
+                                You need to sign in to view this server's leaderboard.
+                            </p>
+                            <SignInButton client:idle redirectTo={`/leaderboard/${serverId}`} />
+                        </div>
+                    )
+                }
+
+                {/** API error **/}
+                {
+                    user && errorMessage && (
+                        <div class="max-w-(--breakpoint-2xl) mx-auto px-3 pt-2">
+                            <div
+                                class="transition duration-300 ease-in-out dark:bg-zinc-900 bg-zinc-100 flex items-center w-full my-4 p-4 px-6 rounded-lg hover:bg-zinc-200 dark:hover:bg-zinc-800 shadow-lg overflow-hidden group"
+                                role="alert"
+                            >
+                                <div class="shrink-0 mr-4">
+                                    <div class="transition duration-300 ease-in-out inline-block dark:bg-zinc-700 bg-zinc-300 p-3 rounded-md dark:group-hover:bg-zinc-600 group-hover:bg-zinc-400">
+                                        <Icon
+                                            name="warning"
+                                            class="h-6 w-6 dark:text-zinc-300 text-zinc-700"
+                                        />
+                                    </div>
+                                </div>
+                                <div class="grow">
+                                    <h1 class="transition duration-300 ease-in-out dark:text-zinc-200 dark:group-hover:text-white text-zinc-800 group-hover:text-zinc-900 font-bold">
+                                        Error
+                                    </h1>
+                                    <p class="transition duration-300 ease-in-out dark:text-zinc-400 dark:group-hover:text-zinc-300 text-zinc-600 group-hover:text-zinc-700">
+                                        Could not load leaderboard data
+                                    </p>
+                                    <p class="transition duration-300 ease-in-out dark:text-zinc-500 dark:group-hover:text-zinc-400 text-zinc-500 group-hover:text-zinc-600 mt-2">
+                                        Please check if the server ID is correct and try again.
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    )
+                }
+
+                {/** Denied: not a bot user **/}
+                {
+                    user && result && !result.authorized && result.reason === "not_bot_user" && (
+                        <div class="text-center py-10 bg-zinc-100 dark:bg-zinc-900 rounded-lg shadow">
+                            <p class="text-gray-700 dark:text-gray-300 mb-2">
+                                Bento Bot doesn't recognise you yet
+                            </p>
+                            <p class="text-sm text-zinc-500 dark:text-zinc-400">
+                                Be active on a server with Bento Bot to access server leaderboards.
+                            </p>
+                        </div>
+                    )
+                }
+
+                {/** Denied: not a member **/}
+                {
+                    user && result && !result.authorized && result.reason === "not_member" && (
+                        <div class="text-center py-10 bg-zinc-100 dark:bg-zinc-900 rounded-lg shadow">
+                            <p class="text-gray-700 dark:text-gray-300 mb-2">Access Denied</p>
+                            <p class="text-sm text-zinc-500 dark:text-zinc-400">
+                                You are not a member of this server, or Bento Bot is not present in
+                                it.
+                            </p>
+                        </div>
+                    )
+                }
+
+                {/** Authorized: show leaderboard **/}
+                {
+                    result && result.authorized && (
+                        <>
+                            <h1 class="mt-2 text-3xl leading-8 font-extrabold tracking-tight dark:text-white text-black sm:text-4xl text-center">
+                                Leaderboard for {result.data.guildName ?? "Bento"}
+                            </h1>
+                            {serverId && result.data.icon && (
+                                <div class="dark:bg-zinc-900/50 bg-zinc-100/50 mx-auto my-auto p-1 mt-8 w-64 rounded-sm shadow-lg">
+                                    <img
+                                        width={256}
+                                        height={256}
+                                        class="mx-auto shadow-lg dark:bg-zinc-800 bg-zinc-200"
+                                        src={result.data.icon}
+                                        alt="Server Icon"
+                                    />
+                                </div>
+                            )}
+                            <div class="max-w-(--breakpoint-2xl) mx-auto px-3 pt-2">
+                                <ul class="relative">
+                                    {result.data.users?.map((DiscordUser) => (
+                                        <div class="shadow-lg">
+                                            <LeaderboardUser {...DiscordUser} />
+                                        </div>
+                                    ))}
+                                </ul>
+                            </div>
+                        </>
+                    )
+                }
             </div>
         </div>
     </SectionWrapper>


### PR DESCRIPTION
## Summary
- Server-specific leaderboards (`/leaderboard/{serverId}`) now require authentication and membership verification
- Calls a new backend endpoint (`/Information/Leaderboard/{guildId}/{userId}`) that combines access check with leaderboard data retrieval
- Shows contextual UI states: sign-in prompt, "not a bot user" nudge, "not a member" denial, or the leaderboard
- Global leaderboard (`/leaderboard`) remains unrestricted

## Changes
- **`src/library/types/interfaces.ts`** — Added `LeaderboardAccessResult` discriminated union type for authorized/denied responses
- **`src/library/server/bentoApi.ts`** — Added `fetchAuthorizedLeaderboard()` that calls the new endpoint and handles 403 gracefully
- **`src/pages/leaderboard/[serverId].astro`** — Replaced public `server:defer` rendering with auth-gated flow using the new endpoint

## Backend dependency
Requires the new `/Information/Leaderboard/{guildId}/{userId}` endpoint on the Bento API, which performs:
1. DB check for user's server membership
2. DB check for user existence in bot data
3. Discord API fallback (`GET /guilds/{guildId}/members/{userId}`) for verification

Returns 200 + leaderboard data on success, or 403 + `{ "reason": "not_bot_user" | "not_member" }` on denial.

## Test plan
- [ ] Visit `/leaderboard/{serverId}` while logged out — should show sign-in prompt
- [ ] Visit `/leaderboard/{serverId}` while logged in as a member — should show leaderboard
- [ ] Visit `/leaderboard/{serverId}` while logged in but not a bot user — should show "be active" message
- [ ] Visit `/leaderboard/{serverId}` while logged in but not a member — should show access denied
- [ ] Visit `/leaderboard` (global) — should still work without auth
- [ ] Verify build passes (`npm run build`)
- [ ] Verify lint passes (`npm run lint`)

Closes #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)