### PR TITLE
feat: user settings, private leaderboard users, public guild leaderboards

### DIFF
--- a/src/components/app/UserMenu.svelte
+++ b/src/components/app/UserMenu.svelte
@@ -146,8 +146,8 @@
                 <MenuItem
                     icon="settings"
                     label="User settings"
-                    disabled={true}
-                    title="Coming Soon™️"
+                    href="/profile/settings"
+                    title="Configure Bento user preferences"
                 />
                 <button
                     role="menuitem"

--- a/src/components/leaderboard/LeaderboardUser.astro
+++ b/src/components/leaderboard/LeaderboardUser.astro
@@ -23,8 +23,15 @@ const rankToNumber = (rank: number) => {
     }
 };
 
-const { rank, level, xp, avatarUrl, username, discriminator } =
-    Astro.props as LeaderboardRankingsInterface;
+const {
+    rank,
+    level,
+    xp,
+    avatarUrl,
+    username,
+    discriminator,
+    private: isPrivate,
+} = Astro.props as LeaderboardRankingsInterface & { private?: boolean };
 
 const rankNumber = Number(rank);
 const topUsersStyle = rankToNumber(rankNumber);
@@ -47,25 +54,38 @@ const messagesToNextLevel = Math.round((level * level * 100 - xp) / 46);
                 {rankNumber}
             </span>
         </div>
-        <img
-            class="w-16 dark:bg-zinc-800 bg-zinc-200 rounded-full inline-block mx-4 whitespace-nowrap overflow-hidden"
-            src={avatarUrl}
-            alt={`${username}'s Avatar`}
-            style={{ textIndent: "100%" }}
-            width={64}
-            height={64}
-        />
-        <span
-            title={username + `#${truncatedDiscriminator}`}
-            class="transition duration-300 ease-in-out text-zinc-400 group-hover:text-zinc-400"
-        >
-            <span
-                class="transition duration-300 ease-in-out dark:text-zinc-200 dark:group-hover:text-white text-zinc-800 group-hover:text-black"
-            >
-                {username}
-            </span>
-            <span>#{truncatedDiscriminator}</span>
-        </span>
+        {
+            isPrivate ? (
+                <>
+                    <div class="w-16 h-16 dark:bg-zinc-700 bg-zinc-300 rounded-full inline-flex items-center justify-center mx-4">
+                        <span class="text-2xl text-zinc-500 dark:text-zinc-400 select-none">?</span>
+                    </div>
+                    <span class="transition duration-300 ease-in-out text-zinc-400 italic">
+                        Private User
+                    </span>
+                </>
+            ) : (
+                <>
+                    <img
+                        class="w-16 dark:bg-zinc-800 bg-zinc-200 rounded-full inline-block mx-4 whitespace-nowrap overflow-hidden"
+                        src={avatarUrl}
+                        alt={`${username}'s Avatar`}
+                        style={{ textIndent: "100%" }}
+                        width={64}
+                        height={64}
+                    />
+                    <span
+                        title={username + `#${truncatedDiscriminator}`}
+                        class="transition duration-300 ease-in-out text-zinc-400 group-hover:text-zinc-400"
+                    >
+                        <span class="transition duration-300 ease-in-out dark:text-zinc-200 dark:group-hover:text-white text-zinc-800 group-hover:text-black">
+                            {username}
+                        </span>
+                        <span>#{truncatedDiscriminator}</span>
+                    </span>
+                </>
+            )
+        }
     </div>
 
     <div class="grow p-4 w-full md:w-auto overflow-hidden">

--- a/src/components/leaderboard/LeaderboardUser.svelte
+++ b/src/components/leaderboard/LeaderboardUser.svelte
@@ -20,9 +20,18 @@
         avatarUrl: string;
         username: string;
         discriminator: string;
+        private?: boolean;
     }
 
-    const { rank, level, xp, avatarUrl, username, discriminator }: Props = $props();
+    const {
+        rank,
+        level,
+        xp,
+        avatarUrl,
+        username,
+        discriminator,
+        private: isPrivate,
+    }: Props = $props();
 
     const rankNumber = $derived(Number(rank));
     const topUsersStyle = $derived(rankToStyle(rankNumber));
@@ -51,25 +60,36 @@
                 {rankNumber}
             </span>
         </div>
-        <img
-            class="w-16 dark:bg-zinc-800 bg-zinc-200 rounded-full inline-block mx-4 whitespace-nowrap overflow-hidden"
-            src={avatarUrl}
-            alt="{username}'s Avatar"
-            style="text-indent: 100%;"
-            width={64}
-            height={64}
-        />
-        <span
-            title="{username}#{truncatedDiscriminator}"
-            class="transition duration-300 ease-in-out text-zinc-400 group-hover:text-zinc-400"
-        >
-            <span
-                class="transition duration-300 ease-in-out dark:text-zinc-200 dark:group-hover:text-white text-zinc-800 group-hover:text-black"
+        {#if isPrivate}
+            <div
+                class="w-16 h-16 dark:bg-zinc-700 bg-zinc-300 rounded-full inline-flex items-center justify-center mx-4"
             >
-                {username}
+                <span class="text-2xl text-zinc-500 dark:text-zinc-400 select-none">?</span>
+            </div>
+            <span class="transition duration-300 ease-in-out text-zinc-400 italic">
+                Private User
             </span>
-            <span>#{truncatedDiscriminator}</span>
-        </span>
+        {:else}
+            <img
+                class="w-16 dark:bg-zinc-800 bg-zinc-200 rounded-full inline-block mx-4 whitespace-nowrap overflow-hidden"
+                src={avatarUrl}
+                alt="{username}'s Avatar"
+                style="text-indent: 100%;"
+                width={64}
+                height={64}
+            />
+            <span
+                title="{username}#{truncatedDiscriminator}"
+                class="transition duration-300 ease-in-out text-zinc-400 group-hover:text-zinc-400"
+            >
+                <span
+                    class="transition duration-300 ease-in-out dark:text-zinc-200 dark:group-hover:text-white text-zinc-800 group-hover:text-black"
+                >
+                    {username}
+                </span>
+                <span>#{truncatedDiscriminator}</span>
+            </span>
+        {/if}
     </div>
 
     <div class="grow p-4 w-full md:w-auto overflow-hidden">

--- a/src/components/settings/UserSettings.svelte
+++ b/src/components/settings/UserSettings.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+    import { actions } from "astro:actions";
+    import type { UserSettingsDto } from "../../library/types/interfaces";
+    import ToggleSwitch from "../profile/ToggleSwitch.svelte";
+    import SaveResetButtons from "../profile/SaveResetButtons.svelte";
+    import StatusMessage from "../profile/StatusMessage.svelte";
+
+    interface Props {
+        initialSettings: UserSettingsDto | null;
+    }
+
+    const { initialSettings }: Props = $props();
+
+    const defaults: UserSettingsDto = {
+        hideSlashCommandCalls: false,
+        showOnGlobalLeaderboard: true,
+    };
+
+    let settings: UserSettingsDto = $state({ ...(initialSettings ?? defaults) });
+    let original: UserSettingsDto = $state({ ...(initialSettings ?? defaults) });
+
+    let saving = $state(false);
+    let error: string | null = $state(null);
+    let savedAt: Date | null = $state(null);
+
+    const hasChanges = $derived(
+        settings.hideSlashCommandCalls !== original.hideSlashCommandCalls ||
+            settings.showOnGlobalLeaderboard !== original.showOnGlobalLeaderboard
+    );
+
+    async function save() {
+        saving = true;
+        error = null;
+
+        // Build patch with only changed fields
+        const patch: Record<string, boolean> = {};
+        if (settings.hideSlashCommandCalls !== original.hideSlashCommandCalls) {
+            patch.hideSlashCommandCalls = settings.hideSlashCommandCalls;
+        }
+        if (settings.showOnGlobalLeaderboard !== original.showOnGlobalLeaderboard) {
+            patch.showOnGlobalLeaderboard = settings.showOnGlobalLeaderboard;
+        }
+
+        const result = await actions.saveUserSettings(patch);
+
+        if (result.error) {
+            error = result.error.message || "Failed to save settings.";
+        } else {
+            original = { ...settings };
+            savedAt = new Date();
+        }
+
+        saving = false;
+    }
+
+    function reset() {
+        settings = { ...original };
+        error = null;
+    }
+</script>
+
+<div class="max-w-xl mx-auto space-y-8">
+    <StatusMessage {error} {saving} {savedAt} />
+
+    <section
+        class="rounded-lg border border-zinc-200 dark:border-zinc-800 bg-zinc-100 dark:bg-zinc-900 p-5 space-y-4"
+    >
+        <h2 class="text-lg font-semibold">Privacy</h2>
+        <ToggleSwitch
+            label="Show on global leaderboard"
+            bind:checked={settings.showOnGlobalLeaderboard}
+        />
+        <p class="text-xs text-zinc-500 dark:text-zinc-400">
+            When disabled, your entry on the global leaderboard will be shown as "Private User" with
+            a hidden avatar.
+        </p>
+    </section>
+
+    <section
+        class="rounded-lg border border-zinc-200 dark:border-zinc-800 bg-zinc-100 dark:bg-zinc-900 p-5 space-y-4"
+    >
+        <h2 class="text-lg font-semibold">Behaviour</h2>
+        <ToggleSwitch
+            label="Hide slash command calls"
+            bind:checked={settings.hideSlashCommandCalls}
+        />
+        <p class="text-xs text-zinc-500 dark:text-zinc-400">
+            When enabled, Bento Bot will attempt to make your slash command responses visible only
+            to you (ephemeral).
+        </p>
+    </section>
+
+    <div class="flex justify-center">
+        <SaveResetButtons {saving} {hasChanges} onSave={save} onReset={reset} responsive />
+    </div>
+</div>
+
+<style>
+    @reference "../../styles/global.css";
+</style>

--- a/src/library/server/bentoApi.ts
+++ b/src/library/server/bentoApi.ts
@@ -1,4 +1,5 @@
 import {
+    type GuildLeaderboardAccessResult,
     type LeaderboardAccessResult,
     type LeaderboardDenialReason,
     type LeaderboardResponseDto,
@@ -6,6 +7,8 @@ import {
     type ProfileDto,
     type ProfilePatch,
     type UsageStatsDto,
+    type UserSettingsDto,
+    type UserSettingsPatch,
 } from "../types/interfaces";
 
 // Cloudflare runtime env, set per-request from middleware
@@ -203,6 +206,52 @@ function buildProfilePayload(profile: ProfilePatch | ProfileDto): string {
     // Serialize and ensure UserId (string of digits) is sent as an unquoted numeric literal
     const json = JSON.stringify(profile);
     return json.replace(/"UserId":"(\d+)"/, '"UserId":$1');
+}
+
+export async function fetchUserSettings(userId: string): Promise<UserSettingsDto> {
+    return fetchFromApi<UserSettingsDto>(`/UserSettings/${userId}`);
+}
+
+export async function saveUserSettings(userId: string, patch: UserSettingsPatch): Promise<void> {
+    if (typeof window !== "undefined") {
+        throw new Error(
+            "saveUserSettings must be called on the server. Use astro:actions from client code."
+        );
+    }
+
+    await fetchFromApi<void>(`/UserSettings/${userId}`, {
+        method: "PUT",
+        body: JSON.stringify(patch),
+    });
+}
+
+export async function fetchPublicGuildLeaderboard(
+    guildId: string
+): Promise<GuildLeaderboardAccessResult> {
+    const url = new URL(`${getApiUrl()}/Information/Leaderboard/${guildId}`);
+
+    // eslint-disable-next-line no-undef
+    const res = await fetch(url.toString(), {
+        headers: {
+            "Content-Type": "application/json",
+            ...(getApiKey() ? { "X-Api-Key": getApiKey()! } : {}),
+        },
+    });
+
+    if (res.status === 403) {
+        return { status: "not_public" };
+    }
+
+    if (res.status === 404) {
+        return { status: "not_found" };
+    }
+
+    if (!res.ok) {
+        throw new Error(`API error: ${res.status} ${res.statusText}`);
+    }
+
+    const data = (await res.json()) as LeaderboardResponseDto;
+    return { status: "accessible", data };
 }
 
 export async function saveUserProfile(profile: ProfilePatch): Promise<void> {

--- a/src/library/types/interfaces.ts
+++ b/src/library/types/interfaces.ts
@@ -22,6 +22,7 @@ export interface LeaderboardUserDto {
     username: string;
     discriminator: string;
     avatarUrl: string;
+    private?: boolean;
 }
 
 export interface LeaderboardResponseDto {
@@ -85,6 +86,31 @@ export interface ProfileDto {
     XpBar2Opacity: number | null;
     XpBar2Colour: string | null;
 }
+
+export interface UserSettingsDto {
+    hideSlashCommandCalls: boolean;
+    showOnGlobalLeaderboard: boolean;
+}
+
+export type UserSettingsPatch = Partial<UserSettingsDto>;
+
+export interface GuildLeaderboardAccessible {
+    status: "accessible";
+    data: LeaderboardResponseDto;
+}
+
+export interface GuildLeaderboardNotPublic {
+    status: "not_public";
+}
+
+export interface GuildLeaderboardNotFound {
+    status: "not_found";
+}
+
+export type GuildLeaderboardAccessResult =
+    | GuildLeaderboardAccessible
+    | GuildLeaderboardNotPublic
+    | GuildLeaderboardNotFound;
 
 export type LeaderboardDenialReason = "not_bot_user" | "not_member";
 

--- a/src/pages/leaderboard/[serverId].astro
+++ b/src/pages/leaderboard/[serverId].astro
@@ -40,6 +40,7 @@ if (serverId) {
                 Astro.response.headers.set("Vary", "Cookie");
             } else {
                 denialReason = result.reason;
+                Astro.response.headers.set("Cache-Control", "no-store");
             }
         } else {
             // Not logged in: use public endpoint
@@ -54,8 +55,10 @@ if (serverId) {
                 );
             } else if (result.status === "not_public") {
                 isPrivateLeaderboard = true;
+                Astro.response.headers.set("Cache-Control", "no-store");
             } else {
                 isNotFound = true;
+                Astro.response.headers.set("Cache-Control", "no-store");
             }
         }
     } catch (error) {

--- a/src/pages/leaderboard/[serverId].astro
+++ b/src/pages/leaderboard/[serverId].astro
@@ -4,29 +4,67 @@ import AppLayout from "../../layouts/app/AppLayout.astro";
 import SectionWrapper from "../../layouts/SectionWrapper.astro";
 import SignInButton from "../../components/auth/SignInButton.svelte";
 import type { BentoBetterAuthUser } from "../../library/auth";
-import { fetchAuthorizedLeaderboard } from "../../library/server/bentoApi";
-import type { LeaderboardAccessResult } from "../../library/types/interfaces";
+import {
+    fetchAuthorizedLeaderboard,
+    fetchPublicGuildLeaderboard,
+} from "../../library/server/bentoApi";
+import type {
+    LeaderboardAccessResult,
+    LeaderboardResponseDto,
+    GuildLeaderboardAccessResult,
+} from "../../library/types/interfaces";
 import { Icon } from "astro-icon/components";
 
 const { serverId } = Astro.params;
 const user = Astro.locals.user as BentoBetterAuthUser | null;
 
-let result: LeaderboardAccessResult | null = null;
+// State variables for template rendering
+let leaderboardData: LeaderboardResponseDto | null = null;
+let denialReason: "not_bot_user" | "not_member" | null = null;
+let isPrivateLeaderboard = false;
+let isNotFound = false;
 let errorMessage: string | undefined;
 
-if (user && serverId) {
+if (serverId) {
     try {
-        result = await fetchAuthorizedLeaderboard(serverId, user.discordId);
-        if (result.authorized) {
-            Astro.response.headers.set("Cache-Control", "private, max-age=3600");
-            Astro.response.headers.set("CDN-Cache-Control", "private, max-age=3600");
-            Astro.response.headers.set("Vary", "Cookie");
+        if (user) {
+            // Logged in: use authorized endpoint (works for both public and private guilds)
+            const result: LeaderboardAccessResult = await fetchAuthorizedLeaderboard(
+                serverId,
+                user.discordId
+            );
+            if (result.authorized) {
+                leaderboardData = result.data;
+                Astro.response.headers.set("Cache-Control", "private, max-age=3600");
+                Astro.response.headers.set("CDN-Cache-Control", "private, max-age=3600");
+                Astro.response.headers.set("Vary", "Cookie");
+            } else {
+                denialReason = result.reason;
+            }
+        } else {
+            // Not logged in: use public endpoint
+            const result: GuildLeaderboardAccessResult =
+                await fetchPublicGuildLeaderboard(serverId);
+            if (result.status === "accessible") {
+                leaderboardData = result.data;
+                Astro.response.headers.set("Cache-Control", "public, max-age=3600, s-maxage=3600");
+                Astro.response.headers.set(
+                    "CDN-Cache-Control",
+                    "public, max-age=3600, s-maxage=3600"
+                );
+            } else if (result.status === "not_public") {
+                isPrivateLeaderboard = true;
+            } else {
+                isNotFound = true;
+            }
         }
     } catch (error) {
         console.error("Error fetching leaderboard data:", error);
         errorMessage = error instanceof Error ? error.message : "An unknown error occurred";
     }
 }
+
+const botCommandTip = "You can also use the /leaderboard server command in Discord.";
 ---
 
 <AppLayout
@@ -36,21 +74,9 @@ if (user && serverId) {
     <SectionWrapper>
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="lg:text-center text-center overflow-hidden">
-                {/** Not signed in **/}
-                {
-                    !user && (
-                        <div class="text-center py-10 bg-zinc-100 dark:bg-zinc-900 rounded-lg shadow">
-                            <p class="text-gray-700 dark:text-gray-300 mb-4">
-                                You need to sign in to view this server's leaderboard.
-                            </p>
-                            <SignInButton client:idle redirectTo={`/leaderboard/${serverId}`} />
-                        </div>
-                    )
-                }
-
                 {/** API error **/}
                 {
-                    user && errorMessage && (
+                    errorMessage && (
                         <div class="max-w-(--breakpoint-2xl) mx-auto px-3 pt-2">
                             <div
                                 class="transition duration-300 ease-in-out dark:bg-zinc-900 bg-zinc-100 flex items-center w-full my-4 p-4 px-6 rounded-lg hover:bg-zinc-200 dark:hover:bg-zinc-800 shadow-lg overflow-hidden group"
@@ -80,9 +106,41 @@ if (user && serverId) {
                     )
                 }
 
+                {/** Not logged in + private leaderboard **/}
+                {
+                    !user && isPrivateLeaderboard && (
+                        <div class="text-center py-10 bg-zinc-100 dark:bg-zinc-900 rounded-lg shadow">
+                            <p class="text-gray-700 dark:text-gray-300 mb-2">
+                                This leaderboard is private
+                            </p>
+                            <p class="text-sm text-zinc-500 dark:text-zinc-400 mb-4">
+                                Sign in with Discord to view this server's leaderboard if you are a
+                                member.
+                            </p>
+                            <SignInButton client:idle redirectTo={`/leaderboard/${serverId}`} />
+                            <p class="text-xs text-zinc-400 dark:text-zinc-500 mt-4">
+                                {botCommandTip}
+                            </p>
+                        </div>
+                    )
+                }
+
+                {/** Not found **/}
+                {
+                    isNotFound && (
+                        <div class="text-center py-10 bg-zinc-100 dark:bg-zinc-900 rounded-lg shadow">
+                            <p class="text-gray-700 dark:text-gray-300 mb-2">Server not found</p>
+                            <p class="text-sm text-zinc-500 dark:text-zinc-400">
+                                The server could not be found. Please check the server ID and try
+                                again.
+                            </p>
+                        </div>
+                    )
+                }
+
                 {/** Denied: not a bot user **/}
                 {
-                    user && result && !result.authorized && result.reason === "not_bot_user" && (
+                    user && denialReason === "not_bot_user" && (
                         <div class="text-center py-10 bg-zinc-100 dark:bg-zinc-900 rounded-lg shadow">
                             <p class="text-gray-700 dark:text-gray-300 mb-2">
                                 Bento Bot doesn't recognise you yet
@@ -90,44 +148,50 @@ if (user && serverId) {
                             <p class="text-sm text-zinc-500 dark:text-zinc-400">
                                 Be active on a server with Bento Bot to access server leaderboards.
                             </p>
+                            <p class="text-xs text-zinc-400 dark:text-zinc-500 mt-4">
+                                {botCommandTip}
+                            </p>
                         </div>
                     )
                 }
 
                 {/** Denied: not a member **/}
                 {
-                    user && result && !result.authorized && result.reason === "not_member" && (
+                    user && denialReason === "not_member" && (
                         <div class="text-center py-10 bg-zinc-100 dark:bg-zinc-900 rounded-lg shadow">
                             <p class="text-gray-700 dark:text-gray-300 mb-2">Access Denied</p>
                             <p class="text-sm text-zinc-500 dark:text-zinc-400">
                                 You are not a member of this server, or Bento Bot is not present in
                                 it.
                             </p>
+                            <p class="text-xs text-zinc-400 dark:text-zinc-500 mt-4">
+                                {botCommandTip}
+                            </p>
                         </div>
                     )
                 }
 
-                {/** Authorized: show leaderboard **/}
+                {/** Leaderboard data **/}
                 {
-                    result && result.authorized && (
+                    leaderboardData && (
                         <>
                             <h1 class="mt-2 text-3xl leading-8 font-extrabold tracking-tight dark:text-white text-black sm:text-4xl text-center">
-                                Leaderboard for {result.data.guildName ?? "Bento"}
+                                Leaderboard for {leaderboardData.guildName ?? "Bento"}
                             </h1>
-                            {serverId && result.data.icon && (
+                            {serverId && leaderboardData.icon && (
                                 <div class="dark:bg-zinc-900/50 bg-zinc-100/50 mx-auto my-auto p-1 mt-8 w-64 rounded-sm shadow-lg">
                                     <img
                                         width={256}
                                         height={256}
                                         class="mx-auto shadow-lg dark:bg-zinc-800 bg-zinc-200"
-                                        src={result.data.icon}
+                                        src={leaderboardData.icon}
                                         alt="Server Icon"
                                     />
                                 </div>
                             )}
                             <div class="max-w-(--breakpoint-2xl) mx-auto px-3 pt-2">
                                 <ul class="relative">
-                                    {result.data.users?.map((DiscordUser) => (
+                                    {leaderboardData.users?.map((DiscordUser) => (
                                         <div class="shadow-lg">
                                             <LeaderboardUser {...DiscordUser} />
                                         </div>

--- a/src/pages/profile.astro
+++ b/src/pages/profile.astro
@@ -108,8 +108,7 @@ const initials = (() => {
                             <ProfileMenuItem
                                 label="User settings"
                                 description="Configure Bento user preferences, privacy etc."
-                                disabled={true}
-                                title="Coming Soon™️"
+                                href="/profile/settings"
                             />
                         </div>
                     </div>

--- a/src/pages/profile/settings.astro
+++ b/src/pages/profile/settings.astro
@@ -1,0 +1,48 @@
+---
+import AppLayout from "../../layouts/app/AppLayout.astro";
+import type { BentoBetterAuthUser } from "../../library/auth";
+import UserSettings from "../../components/settings/UserSettings.svelte";
+import { fetchUserSettings } from "../../library/server/bentoApi";
+import type { UserSettingsDto } from "../../library/types/interfaces";
+
+const user = Astro.locals.user as BentoBetterAuthUser | null;
+
+const title = `User Settings ${user?.name ? `- ${user.name}` : ""}`;
+const description = "Configure your Bento user preferences";
+
+let initialSettings: UserSettingsDto | null = null;
+if (user) {
+    try {
+        initialSettings = await fetchUserSettings(user.discordId);
+    } catch {
+        initialSettings = null;
+    }
+}
+---
+
+<AppLayout title={title} description={description}>
+    <div class="container mx-auto px-4 py-8">
+        <div class="mb-6 flex items-center gap-4">
+            <a href="/profile" class="text-sm text-zinc-600 dark:text-zinc-400 hover:underline"
+                >← Back to Profile</a
+            >
+        </div>
+
+        <h1 class="text-2xl font-bold text-center mb-6 md:mb-8">User Settings</h1>
+
+        {/** Not signed in **/}
+        {
+            !user && (
+                <div class="text-center py-10 bg-zinc-100 dark:bg-zinc-900 rounded-lg shadow">
+                    <p class="text-gray-700 dark:text-gray-300 mb-4">You are not signed in.</p>
+                    <a href="/profile" class="underline">
+                        Go to Profile
+                    </a>
+                </div>
+            )
+        }
+
+        {/** Signed in **/}
+        {user && <UserSettings client:only="svelte" initialSettings={initialSettings} />}
+    </div>
+</AppLayout>


### PR DESCRIPTION
## Summary
- **User settings page** (`/profile/settings`) with Privacy (show on global leaderboard) and Behaviour (hide slash command calls) toggles, backed by new `getUserSettings`/`saveUserSettings` server actions
- **Private user rendering** on global leaderboard: users with `private: true` show a grey "?" placeholder avatar and italic "Private User" instead of their identity
- **Public guild leaderboard access**: non-logged-in users hit the public endpoint (CDN-cacheable); logged-in users use the existing authorized endpoint. Proper denial messages for private guilds, non-members, and unrecognised users, all with `/leaderboard server` bot command tips
- **Settings menu items enabled** in both the profile page and user dropdown

Closes #434, closes #435

## Files Changed
**Created (2):** `src/pages/profile/settings.astro`, `src/components/settings/UserSettings.svelte`

**Modified (8):** `interfaces.ts` (types), `bentoApi.ts` (3 new API functions), `actions/index.ts` (2 new actions), `LeaderboardUser.astro` + `.svelte` (private user rendering), `[serverId].astro` (public/auth strategy rewrite), `profile.astro` + `UserMenu.svelte` (menu enablement)

## Test plan
- [x] Visit `/leaderboard` — verify private users show placeholder avatar + "Private User"
- [x] Visit `/leaderboard/{publicGuildId}` while logged out — should render leaderboard with public cache headers
- [x] Visit `/leaderboard/{privateGuildId}` while logged out — should show "This leaderboard is private" + sign-in button + bot command tip
- [x] Visit `/leaderboard/{privateGuildId}` while logged in as member — should render leaderboard
- [x] Visit `/leaderboard/{privateGuildId}` while logged in as non-member — should show denial + bot command tip
- [x] Visit `/profile/settings` — verify toggles load, save, and reset correctly
- [x] Verify "User settings" links work in both the profile page and user dropdown menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)