### PR TITLE
fix: re-apply theme after View Transitions page swap to prevent FOUC

### DIFF
--- a/src/layouts/app/BaseHead.astro
+++ b/src/layouts/app/BaseHead.astro
@@ -132,6 +132,10 @@ const { title, description = SITE_DESCRIPTION, image = "/29.webp" } = Astro.prop
     };
 
     applyTheme();
+    document.addEventListener("astro:before-swap", (e) => {
+        const isDark = getThemePreference() === "dark";
+        e.newDocument.documentElement.classList[isDark ? "add" : "remove"]("dark");
+    });
     document.addEventListener("astro:after-swap", applyTheme);
 
     if (typeof localStorage !== "undefined") {

--- a/src/layouts/app/BaseHead.astro
+++ b/src/layouts/app/BaseHead.astro
@@ -119,17 +119,22 @@ const { title, description = SITE_DESCRIPTION, image = "/29.webp" } = Astro.prop
 
 <!-- Dark mode script (to prevent flash of incorrect theme) -->
 <script is:inline>
-    const isBrowser = typeof localStorage !== "undefined";
     const getThemePreference = () => {
-        if (isBrowser && localStorage.getItem("theme")) {
+        if (typeof localStorage !== "undefined" && localStorage.getItem("theme")) {
             return localStorage.getItem("theme");
         }
         return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
     };
-    const isDark = getThemePreference() === "dark";
-    document.documentElement.classList[isDark ? "add" : "remove"]("dark");
 
-    if (isBrowser) {
+    const applyTheme = () => {
+        const isDark = getThemePreference() === "dark";
+        document.documentElement.classList[isDark ? "add" : "remove"]("dark");
+    };
+
+    applyTheme();
+    document.addEventListener("astro:after-swap", applyTheme);
+
+    if (typeof localStorage !== "undefined") {
         const observer = new MutationObserver(() => {
             const isDark = document.documentElement.classList.contains("dark");
             localStorage.setItem("theme", isDark ? "dark" : "light");


### PR DESCRIPTION
## Summary

- The `is:inline` theme script in `BaseHead.astro` only ran on initial hard load — Astro's View Transitions replaces the entire `<html>` element with the server-rendered version of the new page, which has no theme class on it
- `ModeWatcher` (`client:load`) would then race to restore the theme asynchronously after each page swap, causing a brief flash of the wrong theme (FOUC)
- Adds an `astro:before-swap` listener that stamps the correct class onto `event.newDocument.documentElement` before the swap — the incoming `<html>` already has the right class when it replaces the current one, eliminating the flash at the source
- Keeps an `astro:after-swap` listener as a secondary guard against `ModeWatcher` briefly removing the class after the swap

## Test plan

- [ ] Toggle theme to dark, navigate between pages — no light flash
- [ ] Toggle theme to light, navigate between pages — no dark flash
- [ ] Hard reload — theme is applied correctly on initial load
- [ ] System preference (no saved theme) — correct theme applied on navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)