### PR TITLE
feat: redesign homepage hero with polished visuals and responsive stats

### DIFF
--- a/src/components/homepage/FeatureImagePreview.astro
+++ b/src/components/homepage/FeatureImagePreview.astro
@@ -66,6 +66,7 @@ const { features, title, subtitle, description } = Astro.props as FeatureImagePr
                             ))
                         }
                     </dl>
+                    <slot name="cta" />
                 </div>
             </div>
             <DiscordFeaturePage client:only="svelte" />

--- a/src/components/homepage/Stats.astro
+++ b/src/components/homepage/Stats.astro
@@ -7,43 +7,41 @@ const users = FormatThousands(usageStats.userCount);
 const servers = Math.max(0, usageStats.serverCount + 1);
 ---
 
-<div class="mt-10 pb-1">
-    <div class="relative">
-        <div class="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="max-w-4xl mx-auto">
-                <dl class="sm:grid sm:grid-cols-3">
-                    <div class="flex flex-col p-6 text-center">
-                        <dt
-                            class="order-2 mt-2 text-lg leading-6 font-medium dark:text-white text-black"
-                        >
-                            Servers
-                        </dt>
-                        <dd class="order-1 text-5xl font-extrabold dark:text-white text-black">
-                            {servers}
-                        </dd>
-                    </div>
-                    <div class="flex flex-col p-6 text-center">
-                        <dt
-                            class="order-2 mt-2 text-lg leading-6 font-medium dark:text-white text-black"
-                        >
-                            Users
-                        </dt>
-                        <dd class="order-1 text-5xl font-extrabold dark:text-white text-black">
-                            {users}
-                        </dd>
-                    </div>
-                    <div class="flex flex-col p-6 text-center">
-                        <dt
-                            class="order-2 mt-2 text-lg leading-6 font-medium dark:text-white text-black"
-                        >
-                            Serving the first Bento
-                        </dt>
-                        <dd class="order-1 text-5xl font-extrabold dark:text-white text-black">
-                            Aug 2021
-                        </dd>
-                    </div>
-                </dl>
-            </div>
+<div class="max-w-2xl mx-auto mt-6 pb-1">
+    <dl
+        class="grid grid-cols-3 divide-x divide-zinc-200/40 dark:divide-zinc-800/40 overflow-hidden rounded-2xl border border-zinc-200/40 dark:border-zinc-800/40 bg-white/20 dark:bg-zinc-900/20 backdrop-blur-md shadow-sm"
+    >
+        <div class="flex flex-col items-center py-6 px-3 sm:px-6">
+            <dd class="text-3xl sm:text-4xl font-black text-zinc-900 dark:text-white tabular-nums">
+                {servers}
+            </dd>
+            <dt
+                class="text-xs sm:text-sm font-medium text-zinc-500 dark:text-zinc-400 mt-1.5 tracking-wide"
+            >
+                Servers
+            </dt>
         </div>
-    </div>
+        <div class="flex flex-col items-center py-6 px-3 sm:px-6">
+            <dd class="text-3xl sm:text-4xl font-black text-zinc-900 dark:text-white tabular-nums">
+                {users}
+            </dd>
+            <dt
+                class="text-xs sm:text-sm font-medium text-zinc-500 dark:text-zinc-400 mt-1.5 tracking-wide"
+            >
+                Users
+            </dt>
+        </div>
+        <div class="flex flex-col items-center py-6 px-3 sm:px-6">
+            <dd
+                class="order-2 sm:order-1 text-xs sm:text-3xl font-medium sm:font-black text-zinc-500 dark:text-zinc-400 sm:text-zinc-900 sm:dark:text-white text-center whitespace-nowrap mt-1.5 sm:mt-0 tracking-wide"
+            >
+                Aug 2021
+            </dd>
+            <dt
+                class="order-1 sm:order-2 text-3xl sm:text-sm font-black sm:font-medium text-zinc-900 dark:text-white sm:text-zinc-500 sm:dark:text-zinc-400 sm:mt-1.5 sm:tracking-wide text-center"
+            >
+                Est.
+            </dt>
+        </div>
+    </dl>
 </div>

--- a/src/components/homepage/StatsSkeleton.astro
+++ b/src/components/homepage/StatsSkeleton.astro
@@ -2,63 +2,65 @@
 
 ---
 
-<div class="mt-10 pb-1">
-    <div class="relative">
-        <div class="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="max-w-4xl mx-auto">
-                <dl class="sm:grid sm:grid-cols-3">
-                    <div class="flex flex-col p-6 text-center">
-                        <dt
-                            class="order-2 mt-2 text-lg leading-6 font-medium dark:text-white text-black"
-                        >
-                            Servers
-                        </dt>
-                        <div class="flex gap-x-2 justify-center items-center h-12">
-                            <span class="sr-only">Loading...</span>
-                            <div
-                                class="h-6 w-6 dark:bg-white bg-black rounded-full animate-bounce [animation-delay:-0.3s]"
-                            >
-                            </div>
-                            <div
-                                class="h-6 w-6 dark:bg-white bg-black rounded-full animate-bounce [animation-delay:-0.15s]"
-                            >
-                            </div>
-                            <div class="h-6 w-6 dark:bg-white bg-black rounded-full animate-bounce">
-                            </div>
-                        </div>
-                    </div>
-                    <div class="flex flex-col p-6 text-center">
-                        <dt
-                            class="order-2 mt-2 text-lg leading-6 font-medium dark:text-white text-black"
-                        >
-                            Users
-                        </dt>
-                        <div class="flex gap-x-2 justify-center items-center h-12">
-                            <span class="sr-only">Loading...</span>
-                            <div
-                                class="h-6 w-6 dark:bg-white bg-black rounded-full animate-bounce [animation-delay:-0.3s]"
-                            >
-                            </div>
-                            <div
-                                class="h-6 w-6 dark:bg-white bg-black rounded-full animate-bounce [animation-delay:-0.15s]"
-                            >
-                            </div>
-                            <div class="h-6 w-6 dark:bg-white bg-black rounded-full animate-bounce">
-                            </div>
-                        </div>
-                    </div>
-                    <div class="flex flex-col p-6 text-center">
-                        <dt
-                            class="order-2 mt-2 text-lg leading-6 font-medium dark:text-white text-black"
-                        >
-                            Serving the first Bento
-                        </dt>
-                        <dd class="order-1 text-5xl font-extrabold dark:text-white text-black">
-                            Aug 2021
-                        </dd>
-                    </div>
-                </dl>
+<div class="max-w-2xl mx-auto mt-6 pb-1">
+    <dl
+        class="grid grid-cols-3 divide-x divide-zinc-200/40 dark:divide-zinc-800/40 overflow-hidden rounded-2xl border border-zinc-200/40 dark:border-zinc-800/40 bg-white/20 dark:bg-zinc-900/20 backdrop-blur-md shadow-sm"
+    >
+        <div class="flex flex-col items-center py-6 px-3 sm:px-6">
+            <div class="flex gap-x-1.5 items-center h-10 sm:h-12">
+                <span class="sr-only">Loading...</span>
+                <div
+                    class="h-2 w-2 sm:h-2.5 sm:w-2.5 bg-zinc-400 dark:bg-zinc-500 rounded-full animate-bounce [animation-delay:-0.3s]"
+                >
+                </div>
+                <div
+                    class="h-2 w-2 sm:h-2.5 sm:w-2.5 bg-zinc-400 dark:bg-zinc-500 rounded-full animate-bounce [animation-delay:-0.15s]"
+                >
+                </div>
+                <div
+                    class="h-2 w-2 sm:h-2.5 sm:w-2.5 bg-zinc-400 dark:bg-zinc-500 rounded-full animate-bounce"
+                >
+                </div>
             </div>
+            <dt
+                class="text-xs sm:text-sm font-medium text-zinc-500 dark:text-zinc-400 mt-1.5 tracking-wide"
+            >
+                Servers
+            </dt>
         </div>
-    </div>
+        <div class="flex flex-col items-center py-6 px-3 sm:px-6">
+            <div class="flex gap-x-1.5 items-center h-10 sm:h-12">
+                <span class="sr-only">Loading...</span>
+                <div
+                    class="h-2 w-2 sm:h-2.5 sm:w-2.5 bg-zinc-400 dark:bg-zinc-500 rounded-full animate-bounce [animation-delay:-0.3s]"
+                >
+                </div>
+                <div
+                    class="h-2 w-2 sm:h-2.5 sm:w-2.5 bg-zinc-400 dark:bg-zinc-500 rounded-full animate-bounce [animation-delay:-0.15s]"
+                >
+                </div>
+                <div
+                    class="h-2 w-2 sm:h-2.5 sm:w-2.5 bg-zinc-400 dark:bg-zinc-500 rounded-full animate-bounce"
+                >
+                </div>
+            </div>
+            <dt
+                class="text-xs sm:text-sm font-medium text-zinc-500 dark:text-zinc-400 mt-1.5 tracking-wide"
+            >
+                Users
+            </dt>
+        </div>
+        <div class="flex flex-col items-center py-6 px-3 sm:px-6">
+            <dd
+                class="order-2 sm:order-1 text-xs sm:text-3xl font-medium sm:font-black text-zinc-500 dark:text-zinc-400 sm:text-zinc-900 sm:dark:text-white text-center whitespace-nowrap mt-1.5 sm:mt-0 tracking-wide"
+            >
+                Aug 2021
+            </dd>
+            <dt
+                class="order-1 sm:order-2 text-3xl sm:text-sm font-black sm:font-medium text-zinc-900 dark:text-white sm:text-zinc-500 sm:dark:text-zinc-400 sm:mt-1.5 sm:tracking-wide text-center"
+            >
+                Est.
+            </dt>
+        </div>
+    </dl>
 </div>

--- a/src/layouts/app/Navigation.astro
+++ b/src/layouts/app/Navigation.astro
@@ -94,17 +94,19 @@ const stickyNavHeaderClass = classNames(
             </div>
         </div>
 
-        <!-- Center section - Mobile Logo -->
+        <!-- Center section - Mobile Logo (hidden on homepage, hero has the logo) -->
         <div class="sm:hidden flex justify-center">
-            <a href="/" data-astro-prefetch class="rounded-full">
-                <span class="sr-only">Home</span>
-                <div
-                    class="gap-x-2 rounded-md p-2 hover:bg-yellow-400 dark:hover:bg-yellow-500 dark:hover:text-black transition-colors duration-300 flex items-center justify-center"
-                >
-                    <span class="font-semibold">Bento</span>
-                    <img src="/29.webp" alt="Logo" class="h-6 w-6 rounded-full" />
-                </div>
-            </a>
+            {
+                currentPath !== "/" && (
+                    <a href="/" data-astro-prefetch class="rounded-full">
+                        <span class="sr-only">Home</span>
+                        <div class="gap-x-2 rounded-md p-2 hover:bg-yellow-400 dark:hover:bg-yellow-500 dark:hover:text-black transition-colors duration-300 flex items-center justify-center">
+                            <span class="font-semibold">Bento</span>
+                            <img src="/29.webp" alt="Logo" class="h-6 w-6 rounded-full" />
+                        </div>
+                    </a>
+                )
+            }
         </div>
 
         <!-- Right section - User Menu (Avatar + Theme/Profile/Login/Logout) -->

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,7 +13,6 @@ Astro.response.headers.set("Cache-Control", "public, max-age=3600");
 Astro.response.headers.set("CDN-Cache-Control", "public, max-age=3600");
 Astro.response.headers.set("Vary", "Cookie");
 
-
 const features: Feature[] = [
     {
         name: "Custom Profiles",
@@ -53,103 +52,120 @@ const featurePreview: FeatureImagePreviewProps = {
 
 <AppLayout title="Bento Bot" description="A Discord bot with media and entertainment commands">
     <div class="flex flex-col min-h-screen overflow-hidden">
-        <div class="w-screen max-w-full min-h-dvh pb-48 flex flex-col relative">
-            <!-- Background with blurred elements -->
-            <div class="fixed inset-0 overflow-hidden -z-10 homepage-bg">
-                <!-- Base background -->
+        <div class="w-screen max-w-full min-h-dvh pb-16 sm:pb-36 lg:pb-48 flex flex-col relative">
+            <div class="fixed inset-0 overflow-hidden -z-10">
                 <div
                     class="absolute inset-0 bg-gradient-to-br from-amber-50 via-yellow-50 to-orange-100 dark:from-black dark:via-zinc-950 dark:to-black"
                 >
                 </div>
 
-                <!-- Blurred background elements -->
-                <div class="absolute inset-0">
-                    <!-- Large blurred circle - top left -->
-                    <div
-                        class="absolute -top-40 -left-40 w-80 h-80 md:w-96 md:h-96 bg-gradient-to-br from-yellow-400/40 to-amber-500/30 dark:from-yellow-500/50 dark:to-amber-600/40 rounded-full blur-3xl"
-                    >
-                    </div>
-
-                    <!-- Medium blurred circle - top right -->
-                    <div
-                        class="absolute -top-20 -right-32 w-64 h-64 md:w-72 md:h-72 bg-gradient-to-bl from-amber-400/35 to-yellow-500/25 dark:from-amber-500/45 dark:to-yellow-600/35 rounded-full blur-2xl"
-                    >
-                    </div>
-
-                    <!-- Large blurred circle - bottom right -->
-                    <div
-                        class="absolute -bottom-32 -right-20 w-72 h-72 md:w-96 md:h-96 bg-gradient-to-tl from-yellow-500/30 to-orange-400/25 dark:from-yellow-300/40 dark:to-orange-500/30 rounded-full blur-3xl"
-                    >
-                    </div>
-
-                    <!-- Medium blurred circle - bottom left -->
-                    <div
-                        class="absolute -bottom-20 -left-20 w-60 h-60 md:w-72 md:h-72 bg-gradient-to-tr from-amber-500/35 to-yellow-400/30 dark:from-amber-600/45 dark:to-yellow-500/40 rounded-full blur-2xl"
-                    >
-                    </div>
-
-                    <!-- Small accent circles -->
-                    <div
-                        class="absolute top-1/3 left-1/4 w-24 h-24 md:w-32 md:h-32 bg-yellow-400/30 dark:bg-yellow-500/45 rounded-full blur-xl"
-                    >
-                    </div>
-                    <div
-                        class="absolute top-2/3 right-1/3 w-16 h-16 md:w-24 md:h-24 bg-amber-400/35 dark:bg-amber-500/50 rounded-full blur-lg"
-                    >
-                    </div>
+                <div class="absolute inset-0 dot-grid opacity-40 dark:opacity-25"></div>
+                <div
+                    class="absolute top-1/3 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[650px] h-[500px] bg-amber-400/10 dark:bg-yellow-500/15 rounded-full blur-[120px]"
+                >
                 </div>
-
-                <!-- Noise overlay for texture -->
+                <div
+                    class="absolute -top-24 -right-24 w-80 h-80 bg-amber-300/20 dark:bg-amber-600/20 rounded-full blur-3xl"
+                >
+                </div>
+                <div
+                    class="absolute bottom-1/4 -left-16 w-64 h-64 bg-amber-400/15 dark:bg-yellow-500/20 rounded-full blur-3xl"
+                >
+                </div>
                 <div
                     class="absolute inset-0 opacity-[0.015] dark:opacity-[0.03]"
                     style="background-image: url('data:image/svg+xml,%3Csvg viewBox=\'0 0 256 256\' xmlns=\'http://www.w3.org/2000/svg\'%3E%3Cfilter id=\'noiseFilter\'%3E%3CfeTurbulence type=\'fractalNoise\' baseFrequency=\'0.9\' numOctaves=\'4\' stitchTiles=\'stitch\'/%3E%3C/filter%3E%3Crect width=\'100%25\' height=\'100%25\' filter=\'url(%23noiseFilter)\'/%3E%3C/svg%3E');"
                 >
                 </div>
             </div>
-            <SectionWrapper>
-                <h1
-                    class="text-center transition-colors duration-1000 text-8xl font-extrabold text-transparent bg-clip-text bg-linear-to-r dark:from-yellow-300 dark:to-yellow-500 from-black to-amber-500"
-                >
-                    Bento
-                </h1>
-                <p class="text-center text-black dark:text-gray-50 text-lg">
-                    A Discord bot with media and entertainment commands, verified by{" "}
-                    <span class="text-discordBlue">Discord</span>
-                </p>
-                <div>
+            <section
+                class="flex flex-col items-center text-center pt-8 sm:pt-12 lg:pt-16 pb-4 px-6 relative z-10"
+            >
+                <div class="hero-enter hero-enter-1 mb-8 relative">
                     <div
-                        class="hover:bg-yellow-500 bg-yellow-400 w-72 mx-auto rounded-xl flex justify-center transition-colors duration-300 ease-in-out"
+                        class="absolute -inset-4 rounded-full bg-amber-400/20 dark:bg-yellow-400/25 blur-xl"
                     >
-                        <a
-                            class="w-full h-full text-center p-3 rounded-xl"
-                            href="https://discord.com/api/oauth2/authorize?client_id=787041583580184609&permissions=1644167687254&scope=bot%20applications.commands"
-                        >
-                            <span class="text-black font-bold">Add Bento to your server</span>
-                        </a>
+                    </div>
+                    <div
+                        class="relative rounded-full p-[3px] bg-linear-to-br from-amber-300 to-amber-500 dark:from-yellow-300 dark:to-amber-500 shadow-lg shadow-amber-400/20 dark:shadow-yellow-400/15"
+                    >
+                        <img
+                            src="/29.webp"
+                            alt="Bento Bot"
+                            class="w-28 h-28 sm:w-32 sm:h-32 rounded-full block"
+                            loading="eager"
+                        />
                     </div>
                 </div>
-                <div>
-                    <div
-                        class="bg-linear-to-r from-yellow-400 to-amber-400 w-72 mx-auto rounded-xl p-[2px] flex justify-center"
+                <div class="hero-enter hero-enter-2 relative mb-5 w-fit">
+                    <h1
+                        class="text-8xl sm:text-9xl font-black tracking-tighter leading-none text-transparent bg-clip-text bg-linear-to-br from-zinc-900 to-amber-600 dark:from-yellow-200 dark:to-amber-400"
                     >
-                        <div
-                            class="dark:bg-black bg-white dark:text-white text-black hover:text-black dark:hover:text-black dark:hover:bg-transparent hover:bg-transparent w-full mx-auto rounded-xl flex justify-center transition-colors duration-300 ease-in-out"
+                        Bento
+                    </h1>
+                    <div class="hidden sm:block absolute top-0 left-full -translate-x-6">
+                        <span
+                            class="inline-flex items-center gap-1 px-2 py-1 rounded-full text-[9px] font-semibold whitespace-nowrap bg-[#5865F2]/10 dark:bg-[#5865F2]/15 text-[#5865F2] dark:text-[#7289da] border border-[#5865F2]/20 dark:border-[#5865F2]/30"
                         >
-                            <a
-                                class="w-full h-full text-center p-3 rounded-xl"
-                                href="/#Main Features"
+                            <svg
+                                class="w-2.5 h-2.5 shrink-0"
+                                viewBox="0 0 127.14 96.36"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                                xmlns="http://www.w3.org/2000/svg"
+                                aria-hidden="true"
                             >
-                                <span class="font-bold">Check out Bento&apos;s features</span>
-                            </a>
-                        </div>
+                                <path
+                                    d="M107.7,8.07A105.15,105.15,0,0,0,81.47,0a72.06,72.06,0,0,0-3.36,6.83A97.68,97.68,0,0,0,49,6.83,72.37,72.37,0,0,0,45.64,0,105.89,105.89,0,0,0,19.39,8.09C2.79,32.65-1.71,56.6.54,80.21h0A105.73,105.73,0,0,0,32.71,96.36,77.7,77.7,0,0,0,39.6,85.25a68.42,68.42,0,0,1-10.85-5.18c.91-.66,1.8-1.34,2.66-2a75.57,75.57,0,0,0,64.32,0c.87.71,1.76,1.39,2.66,2a68.68,68.68,0,0,1-10.87,5.19,77,77,0,0,0,6.89,11.1A105.25,105.25,0,0,0,126.6,80.22h0C129.24,52.84,122.09,29.11,107.7,8.07ZM42.45,65.69C36.18,65.69,31,60,31,53s5-12.74,11.43-12.74S54,46,53.89,53,48.84,65.69,42.45,65.69Zm42.24,0C78.41,65.69,73.25,60,73.25,53s5-12.74,11.44-12.74S96.23,46,96.12,53,91.08,65.69,84.69,65.69Z"
+                                ></path>
+                            </svg>
+                            Verified by Discord
+                        </span>
                     </div>
                 </div>
-            </SectionWrapper>
-            <SectionWrapper>
+                <p class="hero-enter hero-enter-3 max-w-md mb-5 sm:mb-10 leading-relaxed">
+                    <span class="text-lg sm:text-xl text-zinc-600 dark:text-zinc-400"
+                        >Your Discord Bento Bot</span
+                    ><br />
+                    <span class="text-sm sm:text-base text-zinc-500 dark:text-zinc-500"
+                        >Small features, carefully arranged</span
+                    >
+                </p>
+                <div class="hero-enter hero-enter-3 sm:hidden mb-6">
+                    <span
+                        class="inline-flex items-center gap-1 px-2 py-1 rounded-full text-[9px] font-semibold whitespace-nowrap bg-[#5865F2]/10 dark:bg-[#5865F2]/15 text-[#5865F2] dark:text-[#7289da] border border-[#5865F2]/20 dark:border-[#5865F2]/30"
+                    >
+                        <svg
+                            class="w-2.5 h-2.5 shrink-0"
+                            viewBox="0 0 127.14 96.36"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                            xmlns="http://www.w3.org/2000/svg"
+                            aria-hidden="true"
+                        >
+                            <path
+                                d="M107.7,8.07A105.15,105.15,0,0,0,81.47,0a72.06,72.06,0,0,0-3.36,6.83A97.68,97.68,0,0,0,49,6.83,72.37,72.37,0,0,0,45.64,0,105.89,105.89,0,0,0,19.39,8.09C2.79,32.65-1.71,56.6.54,80.21h0A105.73,105.73,0,0,0,32.71,96.36,77.7,77.7,0,0,0,39.6,85.25a68.42,68.42,0,0,1-10.85-5.18c.91-.66,1.8-1.34,2.66-2a75.57,75.57,0,0,0,64.32,0c.87.71,1.76,1.39,2.66,2a68.68,68.68,0,0,1-10.87,5.19,77,77,0,0,0,6.89,11.1A105.25,105.25,0,0,0,126.6,80.22h0C129.24,52.84,122.09,29.11,107.7,8.07ZM42.45,65.69C36.18,65.69,31,60,31,53s5-12.74,11.43-12.74S54,46,53.89,53,48.84,65.69,42.45,65.69Zm42.24,0C78.41,65.69,73.25,60,73.25,53s5-12.74,11.44-12.74S96.23,46,96.12,53,91.08,65.69,84.69,65.69Z"
+                            ></path>
+                        </svg>
+                        Verified by Discord
+                    </span>
+                </div>
+                <div
+                    class="hero-enter hero-enter-4 flex flex-col sm:flex-row gap-3 w-full max-w-xs sm:max-w-none sm:w-auto items-center"
+                >
+                    <a
+                        href="https://discord.com/api/oauth2/authorize?client_id=787041583580184609&permissions=1644167687254&scope=bot%20applications.commands"
+                        class="inline-flex items-center justify-center px-7 py-3.5 rounded-xl font-bold text-zinc-900 bg-amber-400 hover:bg-amber-500 dark:bg-yellow-400 dark:hover:bg-yellow-500 transition-all duration-200 shadow-lg shadow-amber-400/25 dark:shadow-yellow-400/15 w-full sm:w-auto text-sm sm:text-base"
+                    >
+                        Add Bento to your server
+                    </a>
+                </div>
+            </section>
+            <div class="relative z-10 px-4 sm:px-6">
                 <Stats server:defer>
                     <StatsSkeleton slot="fallback" />
                 </Stats>
-            </SectionWrapper>
+            </div>
             <Waves />
         </div>
         <div class="bg-white dark:bg-black">
@@ -160,7 +176,16 @@ const featurePreview: FeatureImagePreviewProps = {
                     title={featurePreview.title}
                     subtitle={featurePreview.subtitle}
                     right
-                />
+                >
+                    <div slot="cta" class="mt-8">
+                        <a
+                            href="/#Main Features"
+                            class="inline-flex items-center justify-center px-7 py-3.5 rounded-xl font-bold text-zinc-800 dark:text-zinc-200 bg-white/60 dark:bg-zinc-900/60 border border-zinc-300 dark:border-zinc-700 hover:border-amber-400 dark:hover:border-amber-400 hover:text-amber-700 dark:hover:text-amber-400 transition-all duration-200 backdrop-blur-sm text-sm sm:text-base"
+                        >
+                            Check out Bento&apos;s features
+                        </a>
+                    </div>
+                </FeatureImagePreview>
             </SectionWrapper>
         </div>
     </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -78,4 +78,43 @@
     opacity: 100;
 }
 
-/* Background styles are now inline in the index.astro file */
+/* Dot grid background pattern for homepage */
+.dot-grid {
+    background-image: radial-gradient(circle, rgba(0, 0, 0, 0.08) 1px, transparent 1px);
+    background-size: 28px 28px;
+}
+.dark .dot-grid {
+    background-image: radial-gradient(circle, rgba(255, 255, 255, 0.05) 1px, transparent 1px);
+}
+
+/* Hero entrance animation */
+@keyframes heroFadeUp {
+    from {
+        opacity: 0;
+        transform: translateY(14px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.hero-enter {
+    opacity: 0;
+    animation: heroFadeUp 0.55s ease forwards;
+}
+.hero-enter-1 {
+    animation-delay: 0.05s;
+}
+.hero-enter-2 {
+    animation-delay: 0.15s;
+}
+.hero-enter-3 {
+    animation-delay: 0.25s;
+}
+.hero-enter-4 {
+    animation-delay: 0.35s;
+}
+.hero-enter-5 {
+    animation-delay: 0.45s;
+}


### PR DESCRIPTION
## Summary

- Overhauls the homepage hero with a logo + gradient ring, staggered fade-up entrance animations, gradient title, and a Discord verified badge (inline on desktop, below description on mobile)
- Replaces the old stats grid with a frosted-glass card and dot-grid background
- Fixes the Est. column in the stats card to swap label/value hierarchy on mobile so all three columns look visually aligned
- Hides the mobile nav logo/text when on the homepage (hero already has the logo)
- Adds a CTA slot to `FeatureImagePreview` so the features section renders the "Check out Bento's features" button

## Test plan

- [ ] Desktop: hero logo, title, badge, stats all render correctly
- [ ] Mobile: "Verified by Discord" shows below description; nav logo hidden on `/`; stats Est. column shows "Est." large with "Aug 2021" small below
- [ ] Dark mode: frosted glass, gradient title, and badge all look correct
- [ ] Features section: "Check out Bento's features" button appears below the feature list

🤖 Generated with [Claude Code](https://claude.com/claude-code)