### PR TITLE
fix(Navigation): restore blur-on-scroll behaviour for navbar

### DIFF
--- a/src/layouts/app/NavBlurHandler.svelte
+++ b/src/layouts/app/NavBlurHandler.svelte
@@ -6,7 +6,7 @@
 
         const updateBlur = () => {
             if (!nav) return;
-            if (document.body.classList.contains("mobile-menu-open")) {
+            if (document.body.classList.contains("mobile-menu-open") || window.scrollY <= 1) {
                 nav.classList.remove("backdrop-blur-xs");
             } else {
                 nav.classList.add("backdrop-blur-xs");

--- a/src/layouts/app/Navigation.astro
+++ b/src/layouts/app/Navigation.astro
@@ -24,11 +24,7 @@ const isCurrentRoute = (route: string): boolean => {
 };
 
 const stickyNavHeaderClass = classNames(
-    "flex flex-col items-center w-full sticky top-0 z-20 sm:bg-inherit/30",
-    // eslint-disable-next-line no-undef
-    typeof window !== "undefined" && document.body.classList.contains("mobile-menu-open")
-        ? ""
-        : "backdrop-blur-xs"
+    "flex flex-col items-center w-full sticky top-0 z-20 sm:bg-inherit/30"
 );
 ---
 
@@ -137,10 +133,11 @@ const stickyNavHeaderClass = classNames(
     const nav = document.getElementById("stickyNav");
 
     const updateBlur = () => {
-        if (document.body.classList.contains("mobile-menu-open")) {
-            nav?.classList.remove("backdrop-blur-xs");
+        if (!nav) return;
+        if (document.body.classList.contains("mobile-menu-open") || window.scrollY <= 1) {
+            nav.classList.remove("backdrop-blur-xs");
         } else {
-            nav?.classList.add("backdrop-blur-xs");
+            nav.classList.add("backdrop-blur-xs");
         }
     };
 
@@ -160,6 +157,7 @@ const stickyNavHeaderClass = classNames(
                 "shadow-xs"
             );
         }
+        updateBlur();
     });
 
     const observer = new MutationObserver(updateBlur);


### PR DESCRIPTION
## Summary
- Navbar backdrop blur was always active due to a server-side conditional (`typeof window !== "undefined"`) that always evaluates to `false` during SSR, so `backdrop-blur-xs` was hardcoded into the static class
- Removed blur from the static class so the navbar starts transparent at the top
- Both the inline scroll handler and `NavBlurHandler.svelte` now gate `backdrop-blur-xs` behind `window.scrollY > 1`, restoring the original behaviour where blur + faint border only appear after the user scrolls

## Test plan
- [ ] Verify navbar has no blur/border when at the top of the page
- [ ] Verify navbar gains blur + faint border after scrolling down
- [ ] Verify blur disappears again when scrolling back to the top
- [ ] Verify mobile menu still removes blur when open

🤖 Generated with [Claude Code](https://claude.com/claude-code)