### PR TITLE
feat: add C# brand colour to about page

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -60,7 +60,7 @@ import Paragraph from "../layouts/Paragraph.astro";
                 href="https://dotnet.microsoft.com"
                 target="_blank"
                 rel="noreferrer"
-                class="dark:text-white text-black hover:underline"
+                class="text-csharp hover:underline"
             >
                 C#
             </a> and uses the{" "}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -13,6 +13,7 @@
     --color-patreon: #ff424d;
     --color-astro: #ff5d01;
     --color-svelte: #ff3e00;
+    --color-csharp: #9b4f96;
 
     /* Animations: you can use these with arbitrary values or add utility classes below */
     --animation-pulse-bento: pulse 4s cubic-bezier(0.4, 0, 0.6, 1) infinite;


### PR DESCRIPTION
## Summary

- Adds `--color-csharp: #9b4f96` (the official C# purple) to the Tailwind theme in `global.css`
- Applies `text-csharp` to the C# link on the about page, consistent with other brand colours (Discord, PostgreSQL, Astro, etc.)

## Test plan

- [ ] Visit `/about` and verify the C# link renders in purple (`#9b4f96`)
- [ ] Check both light and dark mode