### PR TITLE
feat: prerender changelog with incremental loading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
                 "tailwindcss": "^4.3.3",
                 "typescript": "^7.0.2",
                 "typescript-eslint": "^8.65.0",
+                "vitest": "^4.1.10",
                 "wrangler": "^4.114.0"
             },
             "engines": {
@@ -4261,6 +4262,17 @@
                 "tslib": "^2.4.0"
             }
         },
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
+            }
+        },
         "node_modules/@types/debug": {
             "version": "4.1.13",
             "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -4269,6 +4281,13 @@
             "dependencies": {
                 "@types/ms": "*"
             }
+        },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/esrecurse": {
             "version": "4.3.1",
@@ -4968,6 +4987,119 @@
             "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
             "license": "ISC"
         },
+        "node_modules/@vitest/expect": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+            "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.1.0",
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "chai": "^6.2.2",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/mocker": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+            "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "4.1.10",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+            "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+            "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "4.1.10",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+            "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "magic-string": "^0.30.21",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/spy": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+            "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+            "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.10",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
         "node_modules/acorn": {
             "version": "8.16.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -5095,6 +5227,16 @@
             "license": "Apache-2.0",
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/astro": {
@@ -5979,6 +6121,16 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/chai": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/character-entities": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
@@ -6197,6 +6349,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/cookie": {
             "version": "1.1.1",
@@ -7711,6 +7870,16 @@
                 "node": ">=4.0"
             }
         },
+        "node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
         "node_modules/esutils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -7727,6 +7896,16 @@
             "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/expect-type": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+            "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
+            }
         },
         "node_modules/exsolve": {
             "version": "1.0.8",
@@ -11149,6 +11328,13 @@
                 "node": ">=20"
             }
         },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/sisteransi": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -11255,6 +11441,20 @@
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
             }
+        },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/std-env": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+            "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/stream-replace-string": {
             "version": "2.0.0",
@@ -11614,6 +11814,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/tinyclip": {
             "version": "0.1.12",
             "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.12.tgz",
@@ -11648,6 +11855,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinyrainbow": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/trim-lines": {
@@ -12182,6 +12399,96 @@
                 }
             }
         },
+        "node_modules/vitest": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+            "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "4.1.10",
+                "@vitest/mocker": "4.1.10",
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/runner": "4.1.10",
+                "@vitest/snapshot": "4.1.10",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "es-module-lexer": "^2.0.0",
+                "expect-type": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "obug": "^2.1.1",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
+                "std-env": "^4.0.0-rc.1",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^1.0.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.1.0",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@opentelemetry/api": "^1.9.0",
+                "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+                "@vitest/browser-playwright": "4.1.10",
+                "@vitest/browser-preview": "4.1.10",
+                "@vitest/browser-webdriverio": "4.1.10",
+                "@vitest/coverage-istanbul": "4.1.10",
+                "@vitest/coverage-v8": "4.1.10",
+                "@vitest/ui": "4.1.10",
+                "happy-dom": "*",
+                "jsdom": "*",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@opentelemetry/api": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser-playwright": {
+                    "optional": true
+                },
+                "@vitest/browser-preview": {
+                    "optional": true
+                },
+                "@vitest/browser-webdriverio": {
+                    "optional": true
+                },
+                "@vitest/coverage-istanbul": {
+                    "optional": true
+                },
+                "@vitest/coverage-v8": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": false
+                }
+            }
+        },
         "node_modules/web-namespaces": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -12229,6 +12536,23 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "scripts": {
         "dev": "astro dev",
         "build": "astro build",
-        "test": "node --test src/library/server/changelog.test.ts",
+        "test": "vitest run",
         "preview": "astro build && wrangler dev --remote",
         "astro": "astro",
         "deploy": "astro build && wrangler deploy",
@@ -63,6 +63,7 @@
         "tailwindcss": "^4.3.3",
         "typescript": "^7.0.2",
         "typescript-eslint": "^8.65.0",
+        "vitest": "^4.1.10",
         "wrangler": "^4.114.0"
     },
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "scripts": {
         "dev": "astro dev",
         "build": "astro build",
+        "test": "node --test src/library/server/changelog.test.ts",
         "preview": "astro build && wrangler dev --remote",
         "astro": "astro",
         "deploy": "astro build && wrangler deploy",

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,8 @@
+# Prerendered changelog assets bypass the Worker middleware.
+/changelog*
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://cdn.discordapp.com https://api.bentobot.xyz https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; frame-src 'self'; frame-ancestors 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests
+  Strict-Transport-Security: max-age=31536000
+  X-Frame-Options: SAMEORIGIN
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=()

--- a/src/components/markdown/ChangelogFeed.svelte
+++ b/src/components/markdown/ChangelogFeed.svelte
@@ -1,0 +1,115 @@
+<script lang="ts">
+    interface Props {
+        totalPages: number;
+    }
+
+    interface ChangelogChunk {
+        html: string;
+        page: number;
+        totalPages: number;
+    }
+
+    const { totalPages }: Props = $props();
+
+    let chunks: ChangelogChunk[] = $state([]);
+    let nextPage = $state(2);
+    let loading = $state(false);
+    let loadError = $state(false);
+    let sentinel: HTMLDivElement;
+
+    const LoadNextPage = async (): Promise<boolean> => {
+        if (loading || nextPage > totalPages) return false;
+
+        loading = true;
+        loadError = false;
+
+        try {
+            const response = await fetch(`/changelog/chunks/${nextPage}.json`, {
+                headers: { Accept: "application/json" },
+            });
+            if (!response.ok) {
+                throw new Error(`Changelog chunk request failed with ${response.status}.`);
+            }
+
+            const chunk = (await response.json()) as ChangelogChunk;
+            if (
+                chunk.page !== nextPage ||
+                chunk.totalPages !== totalPages ||
+                typeof chunk.html !== "string"
+            ) {
+                throw new Error("Changelog chunk response was invalid.");
+            }
+
+            chunks.push(chunk);
+            nextPage += 1;
+            return true;
+        } catch (error) {
+            console.error("Failed to load older changelog releases.", error);
+            loadError = true;
+            return false;
+        } finally {
+            loading = false;
+        }
+    };
+
+    const Retry = () => void LoadNextPage();
+
+    $effect(() => {
+        if (!sentinel || loading || loadError || nextPage > totalPages) return;
+
+        const observer = new IntersectionObserver(
+            (entries) => {
+                if (entries.some((entry) => entry.isIntersecting)) {
+                    void LoadNextPage();
+                }
+            },
+            {
+                rootMargin: "400px 0px",
+            }
+        );
+        observer.observe(sentinel);
+
+        return () => observer.disconnect();
+    });
+</script>
+
+<div
+    class="prose dark:prose-invert lg:prose-xl mx-auto dark:prose-h1:text-white prose-h1:text-black prose-h2:text-yellow-400 dark:prose-h3:text-white prose-h3:text-black dark:prose-p:text-white prose-p:text-black dark:prose-ul:text-white prose-ul:text-black prose-strong:text-yellow-400 prose-a:text-yellow-400"
+    aria-busy={loading}
+>
+    {#each chunks as chunk (chunk.page)}
+        <!-- The HTML is generated from the trusted changelog during the site build. -->
+        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+        {@html chunk.html}
+    {/each}
+</div>
+
+{#if nextPage <= totalPages}
+    <div bind:this={sentinel} class="mx-auto flex min-h-20 max-w-prose items-center justify-center">
+        {#if loadError}
+            <div class="flex flex-col items-center gap-3 text-center">
+                <p role="alert" class="text-sm text-red-600 dark:text-red-400">
+                    Could not load older releases.
+                </p>
+                <button
+                    type="button"
+                    onclick={Retry}
+                    class="cursor-pointer rounded-lg bg-yellow-400 px-4 py-2 font-semibold text-black transition-colors hover:bg-yellow-500 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-yellow-500 dark:hover:bg-yellow-600"
+                    disabled={loading}
+                >
+                    Try again
+                </button>
+            </div>
+        {:else if loading}
+            <div role="status" class="flex items-center gap-2 text-zinc-600 dark:text-zinc-400">
+                <span class="h-2 w-2 animate-bounce rounded-full bg-current [animation-delay:-0.3s]"
+                ></span>
+                <span
+                    class="h-2 w-2 animate-bounce rounded-full bg-current [animation-delay:-0.15s]"
+                ></span>
+                <span class="h-2 w-2 animate-bounce rounded-full bg-current"></span>
+                <span class="sr-only">Loading older releases</span>
+            </div>
+        {/if}
+    </div>
+{/if}

--- a/src/components/markdown/GitHubMarkdown.astro
+++ b/src/components/markdown/GitHubMarkdown.astro
@@ -1,10 +1,6 @@
 ---
-// Import the remark and rehype plugins for markdown processing
-import { unified } from "unified";
-import remarkParse from "remark-parse";
-import remarkGfm from "remark-gfm";
-import remarkRehype from "remark-rehype";
-import rehypeStringify from "rehype-stringify";
+import { renderMarkdown } from "../../library/server/markdown.ts";
+import MarkdownContent from "./MarkdownContent.astro";
 
 interface Props {
     url: string;
@@ -12,26 +8,14 @@ interface Props {
 
 const { url } = Astro.props;
 
-// Fetch markdown content during build time
+// Fetch markdown content when the containing page renders.
 const response = await fetch(url);
 if (!response.ok) {
     throw new Error(`Failed to fetch data from ${url}`);
 }
 
-// Get the markdown content
 const markdownContent = await response.text();
-
-// Process markdown to HTML using unified with remark and rehype
-const htmlContent = await unified()
-    .use(remarkParse) // Parse markdown
-    .use(remarkGfm) // Support GitHub Flavored Markdown
-    .use(remarkRehype) // Convert to HTML AST
-    .use(rehypeStringify) // Convert to HTML string
-    .process(markdownContent);
+const htmlContent = await renderMarkdown(markdownContent);
 ---
 
-<div
-    class="prose dark:prose-invert lg:prose-xl mx-auto dark:prose-h1:text-white prose-h1:text-black prose-h2:text-yellow-400 dark:prose-h3:text-white prose-h3:text-black dark:prose-p:text-white prose-p:text-black dark:prose-ul:text-white prose-ul:text-black prose-strong:text-yellow-400 prose-a:text-yellow-400"
->
-    <Fragment set:html={String(htmlContent)} />
-</div>
+<MarkdownContent html={htmlContent} />

--- a/src/components/markdown/MarkdownContent.astro
+++ b/src/components/markdown/MarkdownContent.astro
@@ -1,0 +1,15 @@
+---
+interface Props {
+    html: string;
+    id?: string;
+}
+
+const { html, id } = Astro.props;
+---
+
+<div
+    {id}
+    class="prose dark:prose-invert lg:prose-xl mx-auto dark:prose-h1:text-white prose-h1:text-black prose-h2:text-yellow-400 dark:prose-h3:text-white prose-h3:text-black dark:prose-p:text-white prose-p:text-black dark:prose-ul:text-white prose-ul:text-black prose-strong:text-yellow-400 prose-a:text-yellow-400"
+>
+    <Fragment set:html={html} />
+</div>

--- a/src/library/server/changelog.test.ts
+++ b/src/library/server/changelog.test.ts
@@ -41,11 +41,12 @@ test("groups releases and keeps a partial final chunk", () => {
     ]);
 });
 
-test("rejects malformed changelog content", () => {
-    assert.throws(
-        () => splitChangelogReleases("# Changelog\n\nNothing released yet."),
-        /at least one level-two release heading/
-    );
+test("returns an empty array when the changelog has no releases", () => {
+    assert.deepEqual(splitChangelogReleases("# Changelog\n\nNothing released yet."), []);
+    assert.deepEqual(splitChangelogReleases(""), []);
+});
+
+test("rejects release headings without a changelog title", () => {
     assert.throws(() => splitChangelogReleases("## 1.0.0"), /must contain a title/);
 });
 
@@ -58,4 +59,12 @@ test("fails when the upstream changelog request fails", async () => {
         loadChangelogPages(async () => new Response("", { status: 503 })),
         /Failed to fetch changelog: 503/
     );
+});
+
+test("returns no pages when the upstream changelog has no releases", async () => {
+    const pages = await loadChangelogPages(
+        async () => new Response("# Changelog\n\nNothing released yet.")
+    );
+
+    assert.deepEqual(pages, []);
 });

--- a/src/library/server/changelog.test.ts
+++ b/src/library/server/changelog.test.ts
@@ -1,5 +1,4 @@
-import assert from "node:assert/strict";
-import test from "node:test";
+import { describe, expect, it } from "vitest";
 import { groupChangelogReleases, loadChangelogPages, splitChangelogReleases } from "./changelog.ts";
 
 const changelog = `# Changelog
@@ -21,50 +20,55 @@ const changelog = `# Changelog
 * A preserved duplicate
 `;
 
-test("splits releases at level-two headings and preserves duplicates", () => {
-    const releases = splitChangelogReleases(changelog);
+describe("splitChangelogReleases", () => {
+    it("splits releases at level-two headings and preserves duplicates", () => {
+        const releases = splitChangelogReleases(changelog);
 
-    assert.equal(releases.length, 3);
-    assert.match(releases[0]!, /^## \[2\.0\.0]/);
-    assert.match(releases[0]!, /### Features/);
-    assert.match(releases[1]!, /^## 1\.0\.0/);
-    assert.match(releases[2]!, /A preserved duplicate/);
+        expect(releases).toHaveLength(3);
+        expect(releases[0]).toMatch(/^## \[2\.0\.0]/);
+        expect(releases[0]).toMatch(/### Features/);
+        expect(releases[1]).toMatch(/^## 1\.0\.0/);
+        expect(releases[2]).toMatch(/A preserved duplicate/);
+    });
+
+    it("returns an empty array when the changelog has no releases", () => {
+        expect(splitChangelogReleases("# Changelog\n\nNothing released yet.")).toEqual([]);
+        expect(splitChangelogReleases("")).toEqual([]);
+    });
+
+    it("rejects release headings without a changelog title", () => {
+        expect(() => splitChangelogReleases("## 1.0.0")).toThrow(/must contain a title/);
+    });
 });
 
-test("groups releases and keeps a partial final chunk", () => {
-    const releases = ["one", "two", "three", "four", "five"];
+describe("groupChangelogReleases", () => {
+    it("groups releases and keeps a partial final chunk", () => {
+        const releases = ["one", "two", "three", "four", "five"];
 
-    assert.deepEqual(groupChangelogReleases(releases, 2), [
-        ["one", "two"],
-        ["three", "four"],
-        ["five"],
-    ]);
+        expect(groupChangelogReleases(releases, 2)).toEqual([
+            ["one", "two"],
+            ["three", "four"],
+            ["five"],
+        ]);
+    });
+
+    it("rejects invalid page sizes", () => {
+        expect(() => groupChangelogReleases(["one"], 0)).toThrow(/positive integer/);
+    });
 });
 
-test("returns an empty array when the changelog has no releases", () => {
-    assert.deepEqual(splitChangelogReleases("# Changelog\n\nNothing released yet."), []);
-    assert.deepEqual(splitChangelogReleases(""), []);
-});
+describe("loadChangelogPages", () => {
+    it("fails when the upstream changelog request fails", async () => {
+        await expect(
+            loadChangelogPages(async () => new Response("", { status: 503 }))
+        ).rejects.toThrow(/Failed to fetch changelog: 503/);
+    });
 
-test("rejects release headings without a changelog title", () => {
-    assert.throws(() => splitChangelogReleases("## 1.0.0"), /must contain a title/);
-});
+    it("returns no pages when the upstream changelog has no releases", async () => {
+        const pages = await loadChangelogPages(
+            async () => new Response("# Changelog\n\nNothing released yet.")
+        );
 
-test("rejects invalid page sizes", () => {
-    assert.throws(() => groupChangelogReleases(["one"], 0), /positive integer/);
-});
-
-test("fails when the upstream changelog request fails", async () => {
-    await assert.rejects(
-        loadChangelogPages(async () => new Response("", { status: 503 })),
-        /Failed to fetch changelog: 503/
-    );
-});
-
-test("returns no pages when the upstream changelog has no releases", async () => {
-    const pages = await loadChangelogPages(
-        async () => new Response("# Changelog\n\nNothing released yet.")
-    );
-
-    assert.deepEqual(pages, []);
+        expect(pages).toEqual([]);
+    });
 });

--- a/src/library/server/changelog.test.ts
+++ b/src/library/server/changelog.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { groupChangelogReleases, loadChangelogPages, splitChangelogReleases } from "./changelog.ts";
+
+const changelog = `# Changelog
+
+## [2.0.0](https://example.com/2.0.0) (2026-01-02)
+
+### Features
+
+* A feature
+
+## 1.0.0 (2026-01-01)
+
+### Bug Fixes
+
+* A fix
+
+## 1.0.0 (2026-01-01)
+
+* A preserved duplicate
+`;
+
+test("splits releases at level-two headings and preserves duplicates", () => {
+    const releases = splitChangelogReleases(changelog);
+
+    assert.equal(releases.length, 3);
+    assert.match(releases[0]!, /^## \[2\.0\.0]/);
+    assert.match(releases[0]!, /### Features/);
+    assert.match(releases[1]!, /^## 1\.0\.0/);
+    assert.match(releases[2]!, /A preserved duplicate/);
+});
+
+test("groups releases and keeps a partial final chunk", () => {
+    const releases = ["one", "two", "three", "four", "five"];
+
+    assert.deepEqual(groupChangelogReleases(releases, 2), [
+        ["one", "two"],
+        ["three", "four"],
+        ["five"],
+    ]);
+});
+
+test("rejects malformed changelog content", () => {
+    assert.throws(
+        () => splitChangelogReleases("# Changelog\n\nNothing released yet."),
+        /at least one level-two release heading/
+    );
+    assert.throws(() => splitChangelogReleases("## 1.0.0"), /must contain a title/);
+});
+
+test("rejects invalid page sizes", () => {
+    assert.throws(() => groupChangelogReleases(["one"], 0), /positive integer/);
+});
+
+test("fails when the upstream changelog request fails", async () => {
+    await assert.rejects(
+        loadChangelogPages(async () => new Response("", { status: 503 })),
+        /Failed to fetch changelog: 503/
+    );
+});

--- a/src/library/server/changelog.ts
+++ b/src/library/server/changelog.ts
@@ -7,13 +7,12 @@ export const RELEASES_PER_CHUNK = 5;
 export interface ChangelogPage {
     html: string;
     page: number;
-    releaseCount: number;
     totalPages: number;
 }
 
 type ChangelogFetcher = (url: string) => Promise<Response>;
 
-export function splitChangelogReleases(markdown: string): string[] {
+export const splitChangelogReleases = (markdown: string): string[] => {
     const normalizedMarkdown = markdown.replace(/\r\n?/g, "\n").trim();
     const lines = normalizedMarkdown.split("\n");
     const releaseStarts = lines.reduce<number[]>((starts, line, index) => {
@@ -22,7 +21,7 @@ export function splitChangelogReleases(markdown: string): string[] {
     }, []);
 
     if (releaseStarts.length === 0) {
-        throw new Error("Changelog must contain at least one level-two release heading.");
+        return [];
     }
 
     const preamble = lines.slice(0, releaseStarts[0]).join("\n");
@@ -34,12 +33,12 @@ export function splitChangelogReleases(markdown: string): string[] {
         const end = releaseStarts[index + 1] ?? lines.length;
         return lines.slice(start, end).join("\n").trim();
     });
-}
+};
 
-export function groupChangelogReleases(
+export const groupChangelogReleases = (
     releases: string[],
     pageSize = RELEASES_PER_CHUNK
-): string[][] {
+): string[][] => {
     if (!Number.isInteger(pageSize) || pageSize <= 0) {
         throw new Error("Changelog page size must be a positive integer.");
     }
@@ -49,9 +48,11 @@ export function groupChangelogReleases(
         pages.push(releases.slice(index, index + pageSize));
     }
     return pages;
-}
+};
 
-async function buildChangelogPages(fetcher: ChangelogFetcher): Promise<ChangelogPage[]> {
+export const loadChangelogPages = async (
+    fetcher: ChangelogFetcher = (url) => fetch(url)
+): Promise<ChangelogPage[]> => {
     const response = await fetcher(CHANGELOG_URL);
     if (!response.ok) {
         throw new Error(
@@ -67,23 +68,7 @@ async function buildChangelogPages(fetcher: ChangelogFetcher): Promise<Changelog
         chunks.map(async (chunk, index) => ({
             html: await renderMarkdown(chunk.join("\n\n")),
             page: index + 1,
-            releaseCount: chunk.length,
             totalPages,
         }))
     );
-}
-
-let changelogPagesPromise: Promise<ChangelogPage[]> | undefined;
-
-const defaultFetcher: ChangelogFetcher = (url) => fetch(url);
-
-export function loadChangelogPages(
-    fetcher: ChangelogFetcher = defaultFetcher
-): Promise<ChangelogPage[]> {
-    if (fetcher !== defaultFetcher) {
-        return buildChangelogPages(fetcher);
-    }
-
-    changelogPagesPromise ??= buildChangelogPages(defaultFetcher);
-    return changelogPagesPromise;
-}
+};

--- a/src/library/server/changelog.ts
+++ b/src/library/server/changelog.ts
@@ -1,0 +1,89 @@
+import { renderMarkdown } from "./markdown.ts";
+
+export const CHANGELOG_URL =
+    "https://raw.githubusercontent.com/thebentobot/dotBento/master/CHANGELOG.md";
+export const RELEASES_PER_CHUNK = 5;
+
+export interface ChangelogPage {
+    html: string;
+    page: number;
+    releaseCount: number;
+    totalPages: number;
+}
+
+type ChangelogFetcher = (url: string) => Promise<Response>;
+
+export function splitChangelogReleases(markdown: string): string[] {
+    const normalizedMarkdown = markdown.replace(/\r\n?/g, "\n").trim();
+    const lines = normalizedMarkdown.split("\n");
+    const releaseStarts = lines.reduce<number[]>((starts, line, index) => {
+        if (/^##(?:\s|$)/.test(line)) starts.push(index);
+        return starts;
+    }, []);
+
+    if (releaseStarts.length === 0) {
+        throw new Error("Changelog must contain at least one level-two release heading.");
+    }
+
+    const preamble = lines.slice(0, releaseStarts[0]).join("\n");
+    if (!/^#\s+Changelog\s*$/m.test(preamble)) {
+        throw new Error("Changelog must contain a title before its release headings.");
+    }
+
+    return releaseStarts.map((start, index) => {
+        const end = releaseStarts[index + 1] ?? lines.length;
+        return lines.slice(start, end).join("\n").trim();
+    });
+}
+
+export function groupChangelogReleases(
+    releases: string[],
+    pageSize = RELEASES_PER_CHUNK
+): string[][] {
+    if (!Number.isInteger(pageSize) || pageSize <= 0) {
+        throw new Error("Changelog page size must be a positive integer.");
+    }
+
+    const pages: string[][] = [];
+    for (let index = 0; index < releases.length; index += pageSize) {
+        pages.push(releases.slice(index, index + pageSize));
+    }
+    return pages;
+}
+
+async function buildChangelogPages(fetcher: ChangelogFetcher): Promise<ChangelogPage[]> {
+    const response = await fetcher(CHANGELOG_URL);
+    if (!response.ok) {
+        throw new Error(
+            `Failed to fetch changelog: ${response.status} ${response.statusText}`.trim()
+        );
+    }
+
+    const releases = splitChangelogReleases(await response.text());
+    const chunks = groupChangelogReleases(releases);
+    const totalPages = chunks.length;
+
+    return Promise.all(
+        chunks.map(async (chunk, index) => ({
+            html: await renderMarkdown(chunk.join("\n\n")),
+            page: index + 1,
+            releaseCount: chunk.length,
+            totalPages,
+        }))
+    );
+}
+
+let changelogPagesPromise: Promise<ChangelogPage[]> | undefined;
+
+const defaultFetcher: ChangelogFetcher = (url) => fetch(url);
+
+export function loadChangelogPages(
+    fetcher: ChangelogFetcher = defaultFetcher
+): Promise<ChangelogPage[]> {
+    if (fetcher !== defaultFetcher) {
+        return buildChangelogPages(fetcher);
+    }
+
+    changelogPagesPromise ??= buildChangelogPages(defaultFetcher);
+    return changelogPagesPromise;
+}

--- a/src/library/server/markdown.ts
+++ b/src/library/server/markdown.ts
@@ -4,7 +4,7 @@ import remarkGfm from "remark-gfm";
 import remarkRehype from "remark-rehype";
 import rehypeStringify from "rehype-stringify";
 
-export async function renderMarkdown(markdown: string): Promise<string> {
+export const renderMarkdown = async (markdown: string): Promise<string> => {
     const html = await unified()
         .use(remarkParse)
         .use(remarkGfm)
@@ -13,4 +13,4 @@ export async function renderMarkdown(markdown: string): Promise<string> {
         .process(markdown);
 
     return String(html);
-}
+};

--- a/src/library/server/markdown.ts
+++ b/src/library/server/markdown.ts
@@ -1,0 +1,16 @@
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkGfm from "remark-gfm";
+import remarkRehype from "remark-rehype";
+import rehypeStringify from "rehype-stringify";
+
+export async function renderMarkdown(markdown: string): Promise<string> {
+    const html = await unified()
+        .use(remarkParse)
+        .use(remarkGfm)
+        .use(remarkRehype)
+        .use(rehypeStringify)
+        .process(markdown);
+
+    return String(html);
+}

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -2,16 +2,16 @@
 export const prerender = true;
 
 import MarkdownContent from "../components/markdown/MarkdownContent.astro";
+import ChangelogFeed from "../components/markdown/ChangelogFeed.svelte";
 import { CHANGELOG_URL, loadChangelogPages } from "../library/server/changelog.ts";
 import AppLayout from "../layouts/app/AppLayout.astro";
 import SectionWrapper from "../layouts/SectionWrapper.astro";
 
 const changelogPages = await loadChangelogPages();
 const firstPage = changelogPages[0];
-
-if (!firstPage) {
-    throw new Error("The changelog did not produce an initial page.");
-}
+const initialHtml = firstPage
+    ? `<h1>Changelog</h1>${firstPage.html}`
+    : "<h1>Changelog</h1><p>No releases yet.</p>";
 ---
 
 <AppLayout
@@ -19,27 +19,12 @@ if (!firstPage) {
     description="View the changelog of Bento Bot, the Discord bot that provides media and entertainment commands."
 >
     <SectionWrapper>
-        <div data-changelog-feed data-next-page="2" data-total-pages={firstPage.totalPages}>
-            <MarkdownContent id="changelog-entries" html={`<h1>Changelog</h1>${firstPage.html}`} />
+        <div>
+            <MarkdownContent html={initialHtml} />
 
             {
-                firstPage.totalPages > 1 && (
-                    <div class="mx-auto mt-10 flex max-w-prose flex-col items-center gap-3">
-                        <button
-                            data-changelog-load-more
-                            type="button"
-                            aria-controls="changelog-entries"
-                            class="cursor-pointer rounded-lg bg-yellow-400 px-6 py-3 font-semibold text-black transition-colors duration-300 hover:bg-yellow-500 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-yellow-500 dark:hover:bg-yellow-600"
-                        >
-                            Load more
-                        </button>
-                        <p
-                            data-changelog-status
-                            role="status"
-                            aria-live="polite"
-                            class="min-h-6 text-center text-sm text-zinc-600 dark:text-zinc-400"
-                        />
-                    </div>
+                firstPage && firstPage.totalPages > 1 && (
+                    <ChangelogFeed client:load totalPages={firstPage.totalPages} />
                 )
             }
 
@@ -57,75 +42,3 @@ if (!firstPage) {
         </div>
     </SectionWrapper>
 </AppLayout>
-
-<script>
-    interface ChangelogChunk {
-        html: string;
-        page: number;
-        releaseCount: number;
-        totalPages: number;
-    }
-
-    const setupChangelogFeed = () => {
-        const feed = document.querySelector<HTMLElement>("[data-changelog-feed]");
-        if (!feed || feed.dataset.initialized === "true") return;
-
-        const button = feed.querySelector<HTMLButtonElement>("[data-changelog-load-more]");
-        const entries = feed.querySelector<HTMLElement>("#changelog-entries");
-        const status = feed.querySelector<HTMLElement>("[data-changelog-status]");
-        if (!button || !entries || !status) return;
-
-        feed.dataset.initialized = "true";
-
-        const totalPages = Number(feed.dataset.totalPages);
-        let nextPage = Number(feed.dataset.nextPage);
-
-        button.addEventListener("click", async () => {
-            button.disabled = true;
-            button.textContent = "Loading…";
-            status.textContent = "";
-            entries.setAttribute("aria-busy", "true");
-
-            try {
-                const response = await fetch(`/changelog/chunks/${nextPage}.json`, {
-                    headers: { Accept: "application/json" },
-                });
-                if (!response.ok) {
-                    throw new Error(`Changelog chunk request failed with ${response.status}.`);
-                }
-
-                const chunk = (await response.json()) as ChangelogChunk;
-                if (
-                    chunk.page !== nextPage ||
-                    chunk.totalPages !== totalPages ||
-                    typeof chunk.html !== "string"
-                ) {
-                    throw new Error("Changelog chunk response was invalid.");
-                }
-
-                entries.insertAdjacentHTML("beforeend", chunk.html);
-                nextPage += 1;
-                feed.dataset.nextPage = String(nextPage);
-
-                if (nextPage > totalPages) {
-                    button.remove();
-                    status.textContent = "All releases loaded.";
-                } else {
-                    button.disabled = false;
-                    button.textContent = "Load more";
-                    status.textContent = `${chunk.releaseCount} older releases loaded.`;
-                }
-            } catch (error) {
-                console.error("Failed to load older changelog releases.", error);
-                button.disabled = false;
-                button.textContent = "Try again";
-                status.textContent = "Could not load older releases. Please try again.";
-            } finally {
-                entries.removeAttribute("aria-busy");
-            }
-        });
-    };
-
-    setupChangelogFeed();
-    document.addEventListener("astro:page-load", setupChangelogFeed);
-</script>

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -1,19 +1,17 @@
 ---
+export const prerender = true;
+
+import MarkdownContent from "../components/markdown/MarkdownContent.astro";
+import { CHANGELOG_URL, loadChangelogPages } from "../library/server/changelog.ts";
 import AppLayout from "../layouts/app/AppLayout.astro";
 import SectionWrapper from "../layouts/SectionWrapper.astro";
-import GitHubMarkdown from "../components/markdown/GitHubMarkdown.astro";
 
-Astro.response.headers.set(
-    "Cache-Control",
-    // cache for 6 hours
-    "public, max-age=21600"
-);
+const changelogPages = await loadChangelogPages();
+const firstPage = changelogPages[0];
 
-Astro.response.headers.set(
-    "CDN-Cache-Control",
-    // cache for 6 hour
-    "public, max-age=21600"
-);
+if (!firstPage) {
+    throw new Error("The changelog did not produce an initial page.");
+}
 ---
 
 <AppLayout
@@ -21,8 +19,113 @@ Astro.response.headers.set(
     description="View the changelog of Bento Bot, the Discord bot that provides media and entertainment commands."
 >
     <SectionWrapper>
-        <GitHubMarkdown
-            url="https://raw.githubusercontent.com/thebentobot/dotBento/master/CHANGELOG.md"
-        />
+        <div data-changelog-feed data-next-page="2" data-total-pages={firstPage.totalPages}>
+            <MarkdownContent id="changelog-entries" html={`<h1>Changelog</h1>${firstPage.html}`} />
+
+            {
+                firstPage.totalPages > 1 && (
+                    <div class="mx-auto mt-10 flex max-w-prose flex-col items-center gap-3">
+                        <button
+                            data-changelog-load-more
+                            type="button"
+                            aria-controls="changelog-entries"
+                            class="cursor-pointer rounded-lg bg-yellow-400 px-6 py-3 font-semibold text-black transition-colors duration-300 hover:bg-yellow-500 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-yellow-500 dark:hover:bg-yellow-600"
+                        >
+                            Load more
+                        </button>
+                        <p
+                            data-changelog-status
+                            role="status"
+                            aria-live="polite"
+                            class="min-h-6 text-center text-sm text-zinc-600 dark:text-zinc-400"
+                        />
+                    </div>
+                )
+            }
+
+            <noscript>
+                <p class="mx-auto mt-8 max-w-prose text-center text-zinc-700 dark:text-zinc-300">
+                    JavaScript is required to load older releases.{" "}
+                    <a
+                        href={CHANGELOG_URL}
+                        class="text-amber-500 hover:underline dark:text-yellow-400"
+                    >
+                        View the complete changelog on GitHub
+                    </a>.
+                </p>
+            </noscript>
+        </div>
     </SectionWrapper>
 </AppLayout>
+
+<script>
+    interface ChangelogChunk {
+        html: string;
+        page: number;
+        releaseCount: number;
+        totalPages: number;
+    }
+
+    const setupChangelogFeed = () => {
+        const feed = document.querySelector<HTMLElement>("[data-changelog-feed]");
+        if (!feed || feed.dataset.initialized === "true") return;
+
+        const button = feed.querySelector<HTMLButtonElement>("[data-changelog-load-more]");
+        const entries = feed.querySelector<HTMLElement>("#changelog-entries");
+        const status = feed.querySelector<HTMLElement>("[data-changelog-status]");
+        if (!button || !entries || !status) return;
+
+        feed.dataset.initialized = "true";
+
+        const totalPages = Number(feed.dataset.totalPages);
+        let nextPage = Number(feed.dataset.nextPage);
+
+        button.addEventListener("click", async () => {
+            button.disabled = true;
+            button.textContent = "Loading…";
+            status.textContent = "";
+            entries.setAttribute("aria-busy", "true");
+
+            try {
+                const response = await fetch(`/changelog/chunks/${nextPage}.json`, {
+                    headers: { Accept: "application/json" },
+                });
+                if (!response.ok) {
+                    throw new Error(`Changelog chunk request failed with ${response.status}.`);
+                }
+
+                const chunk = (await response.json()) as ChangelogChunk;
+                if (
+                    chunk.page !== nextPage ||
+                    chunk.totalPages !== totalPages ||
+                    typeof chunk.html !== "string"
+                ) {
+                    throw new Error("Changelog chunk response was invalid.");
+                }
+
+                entries.insertAdjacentHTML("beforeend", chunk.html);
+                nextPage += 1;
+                feed.dataset.nextPage = String(nextPage);
+
+                if (nextPage > totalPages) {
+                    button.remove();
+                    status.textContent = "All releases loaded.";
+                } else {
+                    button.disabled = false;
+                    button.textContent = "Load more";
+                    status.textContent = `${chunk.releaseCount} older releases loaded.`;
+                }
+            } catch (error) {
+                console.error("Failed to load older changelog releases.", error);
+                button.disabled = false;
+                button.textContent = "Try again";
+                status.textContent = "Could not load older releases. Please try again.";
+            } finally {
+                entries.removeAttribute("aria-busy");
+            }
+        });
+    };
+
+    setupChangelogFeed();
+    document.addEventListener("astro:page-load", setupChangelogFeed);
+</script>

--- a/src/pages/changelog/chunks/[page].json.ts
+++ b/src/pages/changelog/chunks/[page].json.ts
@@ -1,0 +1,20 @@
+import type { APIRoute, GetStaticPaths } from "astro";
+import { loadChangelogPages, type ChangelogPage } from "../../../library/server/changelog.ts";
+
+export const prerender = true;
+
+export const getStaticPaths = (async () => {
+    const pages = await loadChangelogPages();
+
+    return pages.slice(1).map((page) => ({
+        params: { page: String(page.page) },
+        props: page,
+    }));
+}) satisfies GetStaticPaths;
+
+export const GET: APIRoute<ChangelogPage> = ({ props }) =>
+    new Response(JSON.stringify(props), {
+        headers: {
+            "Content-Type": "application/json; charset=utf-8",
+        },
+    });


### PR DESCRIPTION
## Summary

- prerender the changelog during the website build instead of fetching and parsing it on every request
- render the newest five releases initially and emit older releases as static JSON chunks
- automatically load older chunks as the visitor approaches the bottom of the page
- add accessible loading, retry, ClientRouter, and no-JavaScript behavior
- preserve security headers for prerendered Cloudflare assets
- share Markdown rendering between changelog and GitHub-backed document pages
- add Vitest coverage for changelog splitting, grouping, loading, and empty states

## Performance

- reduces generated initial changelog HTML from about 128 KB to about 30 KB
- removes GitHub and Markdown processing from the visitor request path
- currently generates nine static chunks for the remaining 45 releases

## Validation

- npm test
- npm run lint
- npm run build
- verified five release headings in the initial HTML and each generated chunk
- verified empty changelogs produce no chunk pages
