### PR TITLE
feat: link to Bento documentation

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -4,6 +4,7 @@ export const SITE_TITLE = "Bento";
 export const SITE_DESCRIPTION =
     "Bento is a Discord bot that offers a variety of features to enhance your server experience. It contains a lot of fun and useful commands that will make your server more enjoyable. Small features such as the ability to check the weather, set a reminder, or look up an Urban Dictionary definition, but also";
 export const SITE_URL = "https://bentobot.xyz";
+export const DOCS_URL = "https://docs.bentobot.xyz";
 export const DISCORD_INVITE_URL =
     "https://discord.com/api/oauth2/authorize?client_id=787041583580184609&permissions=1644167687254&scope=bot%20applications.commands";
 

--- a/src/pages/features.astro
+++ b/src/pages/features.astro
@@ -8,7 +8,7 @@ import FeatureImagePreview, {
 } from "../components/homepage/FeatureImagePreview.astro";
 import DiscordFeaturesPage from "../components/features/DiscordFeaturesPage.svelte";
 import DiscordProfilesSetup from "../components/discord/DiscordProfilesSetup.astro";
-import { DISCORD_INVITE_URL } from "../consts";
+import { DISCORD_INVITE_URL, DOCS_URL } from "../consts";
 
 const profileFeatures: Feature[] = [
     {
@@ -105,12 +105,18 @@ const leaderboardFeatures: Feature[] = [
             designed to be useful, fun, and easy to use. Explore some of Bento&apos;s feature
             highlights below. Add Bento to your server to discover the rest of the commands.
         </Paragraph>
-        <div class="flex justify-center">
+        <div class="flex flex-col sm:flex-row justify-center gap-3">
             <a
                 href={DISCORD_INVITE_URL}
                 class="inline-flex items-center justify-center px-7 py-3.5 rounded-xl font-bold text-zinc-900 bg-amber-400 hover:bg-amber-500 dark:bg-yellow-400 dark:hover:bg-yellow-500 transition-all duration-200 shadow-lg shadow-amber-400/25 dark:shadow-yellow-400/15 text-sm sm:text-base"
             >
                 Add Bento to your server
+            </a>
+            <a
+                href={DOCS_URL}
+                class="inline-flex items-center justify-center px-7 py-3.5 rounded-xl font-bold text-zinc-800 dark:text-zinc-200 bg-white/60 dark:bg-zinc-900/60 border border-zinc-300 dark:border-zinc-700 hover:border-amber-400 dark:hover:border-amber-400 hover:text-amber-700 dark:hover:text-amber-400 transition-all duration-200 backdrop-blur-sm text-sm sm:text-base"
+            >
+                Browse the documentation
             </a>
         </div>
     </SectionWrapper>


### PR DESCRIPTION
## Summary

- add a shared URL constant for `https://docs.bentobot.xyz`
- add a secondary documentation button to the Features page beside the Discord invite
- retain the existing light and dark Bento styling

## Validation

- 7 tests passed
- production Astro/Cloudflare build passed
- targeted Prettier check passed

## Note

The repository-wide ESLint command currently cannot start because the installed `typescript-eslint` version does not support the repository's TypeScript 7 dependency; this is unrelated to these changes.